### PR TITLE
Allow text undo after command executed

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -43,7 +43,7 @@ public class CommandBox extends UiPart<Region> {
 
         try {
             commandExecutor.execute(commandText);
-            commandTextField.deleteText(0,commandText.length());
+            commandTextField.deleteText(0, commandText.length());
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -43,7 +43,7 @@ public class CommandBox extends UiPart<Region> {
 
         try {
             commandExecutor.execute(commandText);
-            commandTextField.setText("");
+            commandTextField.deleteText(0,commandText.length());
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         }


### PR DESCRIPTION
Allow text undo in command box after command executed to retrieve last command.

use `ctrl-z` after entering command to retrieve the last input.