### PR TITLE
Alternative Fee calculate number of lessons algo

### DIFF
--- a/src/main/java/seedu/address/logic/FeesCalculator.java
+++ b/src/main/java/seedu/address/logic/FeesCalculator.java
@@ -136,7 +136,6 @@ public class FeesCalculator implements Calculator {
      * Updates the Outstanding Fees field to most recent value and modify the lastAdded date.
      *
      * @param original Outstanding Fees of current amount.
-     * @param updateDay Day of the lesson.
      * @param timeRange Duration per lesson.
      * @param lessonRates Cost per hour for the lesson.
      * @return Updated Outstanding Fees object.
@@ -161,7 +160,19 @@ public class FeesCalculator implements Calculator {
         return durationInHour * lessonRates.getMonetaryValueInFloat();
     }
 
-    // i made it static just to test, and the parameters are not ideal, just for testing to see if it's correct
+
+    /**
+     * Get number of lessons passed after lastUpdated
+     *
+     * @param startDateEndTime The start date of the lesson with the end time
+     * @param endDate The end date of the recurring lesson
+     * @param lastUpdated The last updated date time
+     * @param today The current date time
+     * @param cancelledDates Cancelled dates to exclude
+     * @return
+     */
+    // Note: I made the method static just to test
+    // and the parameters are not ideal, just for testing to see if it's correct
     public static int getNumOfLessonsSinceLastUpdate(LocalDateTime startDateEndTime, LocalDate endDate,
             LocalDateTime lastUpdated, LocalDateTime today, Set<Date> cancelledDates) {
 
@@ -179,7 +190,7 @@ public class FeesCalculator implements Calculator {
         }
         LocalDateTime firstLesson = Collections.max(List.of(lessonAfterUpdate, startDateEndTime));
 
-        // the prev or same dayOfLesson before today
+        // the prev or same dayOfLesson before today, with end time
         LocalDateTime lessonBeforeToday = today.with(TemporalAdjusters.previousOrSame(dayOfLesson)).with(endTime);
         // today is on the day of lesson and before end time
         if (lessonBeforeToday.isAfter(today)) {

--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -229,7 +229,9 @@ public abstract class Lesson implements Comparable<Lesson> {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getTypeOfLesson())
-            .append(" ")
+                .append(" Start date:")
+                .append(getStartDate())
+            .append(" Upcoming:")
             .append(getDisplayDate())
             .append("; Time: ")
             .append(getTimeRange())

--- a/src/test/java/seedu/address/logic/FeesCalculatorTest.java
+++ b/src/test/java/seedu/address/logic/FeesCalculatorTest.java
@@ -2,15 +2,8 @@ package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAdjusters;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This PR is not for merging.

I came up with another algo for calculating number of lessons and tested it a bit.
It will work with lesson endDate once that is out

I ignored code quality for the function parameters etc so just see the algo

Algo:
Example: The lesson is on Tuesday, 1000-1200
lesson has lessonEndDate

1. lessonAfterUpdate = Get the first Tuesday after or equals lastUpdated and set time to 1200
2. If the lessonAfterUpdate is before lastUpdated, means that lastUpdated is on Tues and is after 1200.
so exclude this date and lessonAfterUpdate = lessonAfterUpdate.nextWeek
3. firstLesson = max(lessonAfterUpdate, lessonStartDate) 
4. lessonBeforeToday = Get the first Tuesday before or equals Today and set time to 1200
5. If the lessonBeforeToday is after Today, means that Today is on Tues and is before 1200.
so exclude this date and lessonBeforeToday = lessonBeforeToday.prevWeek
6. lastLesson = min(lessonBeforeToday, lessonEndDate)
7. if lastLesson is before firstLesson, means that no lessons passed 
8. count number of lessons between firstLesson and lastLesson inclusive
9. minus cancelled dates
