### PR TITLE
Fix formatting errors

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,5 +10,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_INVALID_LESSON_DISPLAYED_INDEX =
             "The lesson index provided is invalid for this student";
+    public static final String MESSAGE_CHECK_INPUT = "%1$s\nCheck if you included invalid arguments or prefixes.";
 
 }

--- a/src/main/java/seedu/address/logic/commands/LessonEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LessonEditCommand.java
@@ -47,7 +47,7 @@ public class LessonEditCommand extends UndoableCommand {
 
     public static final String COMMAND_PARAMETERS = "INDEX "
             + "LESSON_INDEX "
-            + "[" + PREFIX_RECURRING + "[END_DATE]]"
+            + "[" + PREFIX_RECURRING + "[END_DATE]] "
             + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_TIME + "HHmm-HHmm] "
             + "[" + PREFIX_SUBJECT + "SUBJECT] "
@@ -68,7 +68,7 @@ public class LessonEditCommand extends UndoableCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the lesson identified by lesson index"
             + " of the student identified by the index number used in the displayed student list.\n"
-            + "Note that you cannot change the type of lesson."
+            + "Note that you cannot change the type of lesson.\n"
             + "Besides cancelled lessons, existing values of other fields will be overwritten by the input values.\n"
             + "Parameters: " + COMMAND_PARAMETERS + "\n"
             + "Example: " + COMMAND_EXAMPLE;

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_CHECK_INPUT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
@@ -22,7 +23,9 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             return new DeleteCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            String.format(MESSAGE_CHECK_INPUT, pe.getMessage()) + "\n"
+                                    + DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_CHECK_INPUT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ACAD_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ACAD_STREAM;
@@ -39,8 +40,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_PARENT_PHONE, PREFIX_PARENT_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_SCHOOL, PREFIX_ACAD_STREAM, PREFIX_ACAD_LEVEL,
+                        PREFIX_PARENT_PHONE, PREFIX_PARENT_EMAIL, PREFIX_ADDRESS, PREFIX_SCHOOL,
+                        PREFIX_ACAD_STREAM, PREFIX_ACAD_LEVEL,
                         PREFIX_REMARK, PREFIX_TAG);
 
         Index index;
@@ -48,7 +49,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            String.format(MESSAGE_CHECK_INPUT, pe.getMessage()) + "\n"
+                                    + EditCommand.MESSAGE_USAGE), pe);
         }
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();

--- a/src/main/java/seedu/address/logic/parser/LessonDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LessonDeleteCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_CHECK_INPUT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
@@ -20,7 +21,9 @@ public class LessonDeleteCommandParser implements Parser<LessonDeleteCommand> {
             return new LessonDeleteCommand(index, lessonIndex);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, LessonDeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            String.format(MESSAGE_CHECK_INPUT, pe.getMessage()) + "\n"
+                                    + LessonDeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/LessonEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LessonEditCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_CHECK_INPUT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CANCEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
@@ -38,16 +39,18 @@ public class LessonEditCommandParser implements Parser<LessonEditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_RECURRING, PREFIX_DATE, PREFIX_TIME,
-                    PREFIX_SUBJECT, PREFIX_HOMEWORK, PREFIX_RATES, PREFIX_OUTSTANDING_FEES,
-                    PREFIX_CANCEL, PREFIX_UNCANCEL);
+                        PREFIX_SUBJECT, PREFIX_HOMEWORK, PREFIX_RATES, PREFIX_OUTSTANDING_FEES,
+                        PREFIX_CANCEL, PREFIX_UNCANCEL);
 
         Index[] indices;
 
         try {
             indices = ParserUtil.parseIndices(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    LessonEditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            String.format(MESSAGE_CHECK_INPUT, pe.getMessage()) + "\n"
+                                    + LessonEditCommand.MESSAGE_USAGE), pe);
         }
 
         assert indices.length == 2;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,7 +37,8 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer. Valid values range "
+            + "from 1 to MAX_INT (2147483627).";
     public static final String MESSAGE_INSUFFICIENT_INDICES = "Specify a valid index for both the student and lesson.";
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,7 +37,7 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer. Valid values range "
+    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer. Valid integers range "
             + "from 1 to MAX_INT (2147483627).";
     public static final String MESSAGE_INSUFFICIENT_INDICES = "Specify a valid index for both the student and lesson.";
 

--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -230,11 +230,12 @@ public abstract class Lesson implements Comparable<Lesson> {
         String typeOfLesson = isRecurring() ? RECURRING : MAKEUP;
 
         builder.append(typeOfLesson)
-                .append("Start date: ")
+                .append(" ")
+                .append("Start Date: ")
                 .append(getStartDate());
 
         if (!getEndDate().equals(Date.MAX_DATE)) {
-            builder.append("; End date: ")
+            builder.append("; End Date: ")
                    .append(getEndDate());
         }
 

--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -239,7 +239,6 @@ public abstract class Lesson implements Comparable<Lesson> {
                    .append(getEndDate());
         }
 
-
         builder.append("; Date: ")
                 .append(getDisplayDate())
                 .append("; Time: ")

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_CHECK_INPUT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -18,6 +19,10 @@ import seedu.address.logic.commands.DeleteCommand;
  */
 public class DeleteCommandParserTest {
 
+    private static final String MESSAGE_INVALID_FORMAT = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        String.format(MESSAGE_CHECK_INPUT, ParserUtil.MESSAGE_INVALID_INDEX)
+            + "\n" + DeleteCommand.MESSAGE_USAGE);
+
     private DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
@@ -27,6 +32,6 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", MESSAGE_INVALID_FORMAT);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_CHECK_INPUT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ACAD_LEVEL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ACAD_STREAM_DESC_AMY;
@@ -63,8 +64,9 @@ public class EditCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
-    private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_FORMAT = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        String.format(MESSAGE_CHECK_INPUT, ParserUtil.MESSAGE_INVALID_INDEX)
+            + "\n" + EditCommand.MESSAGE_USAGE);
 
     private EditCommandParser parser = new EditCommandParser();
 

--- a/src/test/java/seedu/address/logic/parser/LessonDeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LessonDeleteCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_CHECK_INPUT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -12,6 +13,12 @@ import seedu.address.logic.commands.LessonDeleteCommand;
 
 class LessonDeleteCommandParserTest {
 
+    private static final String MESSAGE_INVALID_COMMAND = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            String.format(MESSAGE_CHECK_INPUT, ParserUtil.MESSAGE_INVALID_INDEX)
+                   + "\n" + LessonDeleteCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INSUFFICIENT_INDICES = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            String.format(MESSAGE_CHECK_INPUT, ParserUtil.MESSAGE_INSUFFICIENT_INDICES)
+                  + "\n" + LessonDeleteCommand.MESSAGE_USAGE);
     private LessonDeleteCommandParser parser = new LessonDeleteCommandParser();
 
     @Test
@@ -22,37 +29,31 @@ class LessonDeleteCommandParserTest {
 
     @Test
     public void parse_emptyString_throwsParseException() {
-        assertParseFailure(parser, "",
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, LessonDeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "", MESSAGE_INSUFFICIENT_INDICES);
     }
 
     @Test
     public void parse_negativeArgs_throwsParseException() {
-        assertParseFailure(parser, "-2 1",
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, LessonDeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-2 1", MESSAGE_INVALID_COMMAND);
     }
 
     @Test
     public void parse_singleArg_throwsParseException() {
-        assertParseFailure(parser, "2 ",
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, LessonDeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "2 ", MESSAGE_INSUFFICIENT_INDICES);
     }
 
     @Test
     public void parse_aboveTwoIndicesParseException() {
-        assertParseFailure(parser, "1 2 3 4 5",
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, LessonDeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1 2 3 4 5", MESSAGE_INVALID_COMMAND);
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a 1",
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, LessonDeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a 1", MESSAGE_INVALID_COMMAND);
     }
 
     @Test
     public void parse_invalidArgs2_throwsParseException() {
-        assertParseFailure(parser, "a abdag",
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, LessonDeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a abdag", MESSAGE_INVALID_COMMAND);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/LessonEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LessonEditCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_CHECK_INPUT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.CANCEL_DATE_DESC_MON;
 import static seedu.address.logic.commands.CommandTestUtil.CANCEL_DATE_DESC_NEXT_MON;
@@ -56,19 +57,25 @@ class LessonEditCommandParserTest {
 
     private static final String HOMEWORK_EMPTY = " " + PREFIX_HOMEWORK;
     private static final String MESSAGE_INVALID_FORMAT =
-        String.format(MESSAGE_INVALID_COMMAND_FORMAT, LessonEditCommand.MESSAGE_USAGE);
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    String.format(MESSAGE_CHECK_INPUT, ParserUtil.MESSAGE_INVALID_INDEX)
+                            + "\n" + LessonEditCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INSUFFICIENT_INDICES =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    String.format(MESSAGE_CHECK_INPUT, ParserUtil.MESSAGE_INSUFFICIENT_INDICES)
+                            + "\n" + LessonEditCommand.MESSAGE_USAGE);
     private final LessonEditCommandParser parser = new LessonEditCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, TIME_RANGE_DESC, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, TIME_RANGE_DESC, MESSAGE_INSUFFICIENT_INDICES);
 
         // no field specified
         assertParseFailure(parser, "1 1", LessonEditCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", MESSAGE_INSUFFICIENT_INDICES);
 
         assertParseFailure(parser, "1 1 " + PREFIX_DATE, Date.MESSAGE_CONSTRAINTS);
     }


### PR DESCRIPTION
fix #242 
fix #241 

possibly fix #125 
Message changed to shown user that index (preamble) provided is invalid. Since we need to account for valid index/indices + invalid arguments in preamble, message includes command format, and a warning to user to check if there is any invalid arguments provided that deviates from the command format.

Not sure if we want to add back the (must be positive integer) message since the user might be confused why until MAX_INT if they did not read UG but small thing