### PR TITLE
Debug reminder - time passed lesson not removed from reminder

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -56,6 +56,9 @@ public interface Logic {
     /** Returns an unmodifiable view of the list of upcoming lessons within two days. */
     ObservableList<Entry<Lesson>> getUpcomingLessons();
 
+    /** Updates the list of upcoming lists within two days. */
+    void updateUpcomingLessons();
+
     /**
      * Returns the user prefs' address book file path.
      */

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -122,6 +122,7 @@ public class LogicManager implements Logic {
 
     @Override
     public void updateUpcomingLessons() {
+        logger.info("Update upcoming lessons");
         model.updateUpcomingLessons();
     }
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -121,6 +121,11 @@ public class LogicManager implements Logic {
     }
 
     @Override
+    public void updateUpcomingLessons() {
+        model.updateUpcomingLessons();
+    }
+
+    @Override
     public Path getAddressBookFilePath() {
         return model.getAddressBookFilePath();
     }

--- a/src/main/java/seedu/address/logic/commands/RemindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemindCommand.java
@@ -17,6 +17,7 @@ public class RemindCommand extends Command {
 
     @Override
     public CommandResult execute() {
+        model.updateUpcomingLessons();
         return new CommandResult(SHOWING_REMIND_MESSAGE, CommandResult.DisplayType.REMINDER);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/RemindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemindCommand.java
@@ -17,7 +17,6 @@ public class RemindCommand extends Command {
 
     @Override
     public CommandResult execute() {
-        model.updateUpcomingLessons();
         return new CommandResult(SHOWING_REMIND_MESSAGE, CommandResult.DisplayType.REMINDER);
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -194,13 +194,30 @@ public class AddressBook implements ReadOnlyAddressBook {
         return tags.asUnmodifiableMap();
     }
 
+    /**
+     * Returns the Calendar consisting of all lessons entries.
+     *
+     * @return The Calendar consisting of all lessons entries.
+     */
     public Calendar getCalendar() {
         // TODO: Make defensive
         return entries.getCalendar();
     }
 
+    /**
+     * Returns a list of upcoming lessons within the next two days.
+     *
+     * @return List of upcoming lessons within the next two days.
+     */
     public ObservableList<Entry<Lesson>> getUpcomingLessons() {
         return entries.getUpcomingLessons();
+    }
+
+    /**
+     * Updates the list of upcoming lessons.
+     */
+    public void updateUpcomingLessons() {
+        entries.updateUpcomingLessons();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -101,7 +101,17 @@ public interface Model {
      */
     Calendar getCalendar();
 
+    /**
+     * Returns a list of upcoming lessons within the next two days.
+     *
+     * @return List of upcoming lessons within the next two days.
+     */
     ObservableList<Entry<Lesson>> getUpcomingLessons();
+
+    /**
+     * Updates the list of upcoming lessons.
+     */
+    void updateUpcomingLessons();
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -148,6 +148,11 @@ public class ModelManager implements Model {
         return addressBook.getUpcomingLessons();
     }
 
+    @Override
+    public void updateUpcomingLessons() {
+        addressBook.updateUpcomingLessons();
+    }
+
     /**
      * Returns an unmodifiable view of the observable tag list.
      */

--- a/src/main/java/seedu/address/model/lesson/CalendarEntryList.java
+++ b/src/main/java/seedu/address/model/lesson/CalendarEntryList.java
@@ -35,7 +35,8 @@ import seedu.address.model.person.exceptions.LessonNotFoundException;
  * @see Lesson#isClashing(Lesson)
  */
 public class CalendarEntryList {
-    private static final long TWO_DAY_DIFF = 48;
+    // two day time difference in minutes
+    private static final long TWO_DAY_DIFF = 2880;
 
     private final Calendar calendar = new Calendar();
     private final List<Entry<Lesson>> entryList = new ArrayList<>();
@@ -52,8 +53,18 @@ public class CalendarEntryList {
     private void add(Entry<Lesson> calendarEntry) {
         calendar.addEntry(calendarEntry);
         entryList.add(calendarEntry);
+        addUpcomingLesson(calendarEntry);
+    }
+
+    /**
+     * Adds calendar entry to the list of upcoming lessons if the lesson for the specified calendar entry
+     * is upcoming within the next two days.
+     *
+     * @param calendarEntry Calendar Entry of lesson to be checked and added if it is upcoming.
+     */
+    private void addUpcomingLesson(Entry<Lesson> calendarEntry) {
         Lesson lesson = calendarEntry.getUserObject();
-        if (isUpcoming(lesson.getDisplayEndLocalDateTime())
+        if (isUpcoming(lesson)
                 && upcomingLessons.stream().noneMatch(entry -> entry.getUserObject().equals(lesson))) {
             upcomingLessons.add(calendarEntry);
             sortUpcomingLessons();
@@ -242,14 +253,15 @@ public class CalendarEntryList {
     }
 
     /**
-     * Returns true if the given date and time is within two days of current date time.
+     * Returns true if the lesson start or end time is within two days of current date time.
      *
-     * @param endDateTime Date and time to be checked.
-     * @return True if the given date and time is within two days of current date time.
+     * @param lesson Lesson to be checked.
+     * @return True if the lesson start or end time is within two days of current date time.
      */
-    private boolean isUpcoming(LocalDateTime endDateTime) {
-        long timeDiff = ChronoUnit.HOURS.between(LocalDateTime.now(), endDateTime);
-        return timeDiff >= 0 && timeDiff < TWO_DAY_DIFF;
+    private boolean isUpcoming(Lesson lesson) {
+        long endTimeDiff = ChronoUnit.MINUTES.between(LocalDateTime.now(), lesson.getDisplayEndLocalDateTime());
+        long startTimeDiff = ChronoUnit.MINUTES.between(LocalDateTime.now(), lesson.getDisplayStartLocalDateTime());
+        return endTimeDiff >= 0 && (startTimeDiff < TWO_DAY_DIFF || endTimeDiff < TWO_DAY_DIFF);
     }
 
     /**
@@ -260,6 +272,20 @@ public class CalendarEntryList {
                 .sorted(Comparator.comparing(e -> e.getUserObject().getDisplayEndLocalDateTime()))
                 .collect(Collectors.toList());
         upcomingLessons.setAll(sortedList);
+    }
+
+    /**
+     * Removes lesson entries with end date time that has passed the current time and add new upcoming lessons if any.
+     */
+    public void updateUpcomingLessons() {
+        for (Entry<Lesson> entry : entryList) {
+            Lesson lesson = entry.getUserObject();
+            if (upcomingLessons.contains(entry)
+                    && !isUpcoming(lesson)) {
+                upcomingLessons.remove(entry);
+            }
+            addUpcomingLesson(entry);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -157,6 +157,15 @@ public abstract class Lesson implements Comparable<Lesson> {
     }
 
     /**
+     * Gets the start {@code LocalDateTime} to be displayed.
+     *
+     * @return start {@code LocalDateTime} to be displayed.
+     */
+    public LocalDateTime getDisplayStartLocalDateTime() {
+        return timeRange.getStart().atDate(getDisplayLocalDate());
+    }
+
+    /**
      * Gets the end {@code LocalDateTime} to be displayed.
      *
      * @return End {@code LocalDateTime} to be displayed.

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -250,6 +250,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleReminder() {
+        logic.updateUpcomingLessons();
         if (!reminderWindow.isShowing()) {
             reminderWindow.show();
         } else {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -189,6 +189,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void updateUpcomingLessons() {
+            throw new AssertionError(MESSAGE_UNEXPECTED_METHOD_CALL);
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError(MESSAGE_UNEXPECTED_METHOD_CALL);
         }

--- a/src/test/java/seedu/address/logic/commands/RemindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemindCommandTest.java
@@ -2,20 +2,39 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.RemindCommand.SHOWING_REMIND_MESSAGE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.UndoRedoStack;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 
 class RemindCommandTest {
-    private Model model = new ModelManager();
-    private Model expectedModel = new ModelManager();
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
 
     @Test
     public void execute_remind_success() {
         CommandResult expectedCommandResult =
                 new CommandResult(SHOWING_REMIND_MESSAGE, CommandResult.DisplayType.REMINDER);
-        assertCommandSuccess(new RemindCommand(), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(prepareRemindCommand(), model, expectedCommandResult, expectedModel);
+    }
+
+    /**
+     * Generates a {@code RemindCommand}.
+     */
+    private RemindCommand prepareRemindCommand() {
+        RemindCommand remindCommand = new RemindCommand();
+        remindCommand.setDependencies(model, new UndoRedoStack());
+        return remindCommand;
     }
 }

--- a/src/test/java/seedu/address/model/lesson/CalendarEntryListTest.java
+++ b/src/test/java/seedu/address/model/lesson/CalendarEntryListTest.java
@@ -146,5 +146,4 @@ public class CalendarEntryListTest {
         List<Person> listWithClashingLessons = Arrays.asList(aliceWithLesson, bobWithLesson);
         assertThrows(ClashingLessonException.class, () -> calendarEntryList.resetLessons(listWithClashingLessons));
     }
-
 }

--- a/src/test/java/seedu/address/model/lesson/DateTest.java
+++ b/src/test/java/seedu/address/model/lesson/DateTest.java
@@ -4,6 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalDates.DATE_CURRENT_WEEK;
+import static seedu.address.testutil.TypicalDates.DATE_ONE_WEEK_AGO;
+import static seedu.address.testutil.TypicalDates.DATE_ONE_WEEK_LATER;
+import static seedu.address.testutil.TypicalDates.DATE_TWO_WEEKS_LATER;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -97,9 +101,7 @@ public class DateTest {
     @Test
     public void updateDate_withoutSkipDates() {
         // At least 1 week has passed
-        Date today = DateUtil.build(LocalDate.now());
-        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
-        assertEquals(today, dateOneWeekAgo.updateDate(EMPTY_DATES));
+        assertEquals(DATE_CURRENT_WEEK, DATE_ONE_WEEK_AGO.updateDate(EMPTY_DATES));
 
         // Less than a week has passed but the date is over.
         long daysBefore = 2;
@@ -109,28 +111,21 @@ public class DateTest {
         assertEquals(dateNext, dateLessThanOneWeekAgo.updateDate(EMPTY_DATES));
 
         // Current date (date is not over yet)
-        assertEquals(today, today.updateDate(EMPTY_DATES));
+        assertEquals(DATE_CURRENT_WEEK, DATE_CURRENT_WEEK.updateDate(EMPTY_DATES));
 
         // Future date
-        Date nextWeek = DateUtil.build(LocalDate.now().plusWeeks(1));
-        assertEquals(nextWeek, nextWeek.updateDate(EMPTY_DATES));
+        assertEquals(DATE_ONE_WEEK_LATER, DATE_ONE_WEEK_LATER.updateDate(EMPTY_DATES));
     }
 
     @Test
     public void updateDate_withSkipDates() {
         // Current date skip
-        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
-        Date dateCurrentWeek = DateUtil.build(LocalDate.now());
-        Date dateNextWeek = DateUtil.build(LocalDate.now().plusWeeks(1));
-        Set<Date> cancelledDates = Set.of(dateCurrentWeek);
-
-        assertEquals(dateNextWeek, dateOneWeekAgo.updateDate(cancelledDates));
+        Set<Date> cancelledDates = Set.of(DATE_CURRENT_WEEK);
+        assertEquals(DATE_ONE_WEEK_LATER, DATE_ONE_WEEK_AGO.updateDate(cancelledDates));
 
         // Skip consecutive dates
-        cancelledDates = Set.of(dateCurrentWeek, dateNextWeek);
-        Date dateTwoWeeksLater = DateUtil.build(LocalDate.now().plusWeeks(2));
-
-        assertEquals(dateTwoWeeksLater, dateOneWeekAgo.updateDate(cancelledDates));
+        cancelledDates = Set.of(DATE_CURRENT_WEEK, DATE_ONE_WEEK_LATER);
+        assertEquals(DATE_TWO_WEEKS_LATER, DATE_ONE_WEEK_AGO.updateDate(cancelledDates));
     }
 }
 

--- a/src/test/java/seedu/address/model/lesson/RecurringLessonTest.java
+++ b/src/test/java/seedu/address/model/lesson/RecurringLessonTest.java
@@ -12,6 +12,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_OUTSTANDING_FEE
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBJECT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TIME_RANGE;
 import static seedu.address.model.lesson.Date.MAX_DATE;
+import static seedu.address.testutil.TypicalDates.DATE_CURRENT_WEEK;
+import static seedu.address.testutil.TypicalDates.DATE_ONE_WEEK_AGO;
+import static seedu.address.testutil.TypicalDates.DATE_ONE_WEEK_LATER;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -22,119 +25,101 @@ import java.util.TreeSet;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.testutil.DateUtil;
 import seedu.address.testutil.LessonBuilder;
 
 class RecurringLessonTest {
 
+
     @Test
     public void getDisplayDate_dateNotOver_sameDate() {
-        Date dateCurrentWeek = DateUtil.build(LocalDate.now());
-        Lesson lesson = new LessonBuilder().withDate(dateCurrentWeek).buildRecurring();
-        assertEquals(dateCurrentWeek, lesson.getDisplayDate());
+        Lesson lesson = new LessonBuilder().withDate(DATE_CURRENT_WEEK).buildRecurring();
+        assertEquals(DATE_CURRENT_WEEK, lesson.getDisplayDate());
         assertEquals(LocalDate.now(), lesson.getDisplayLocalDate());
     }
 
     @Test
     public void getDisplayDate_dateOver_showNextDate() {
-        Date currentWeek = DateUtil.build(LocalDate.now());
-        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
-        Lesson lesson = new LessonBuilder().withDate(dateOneWeekAgo).buildRecurring();
-        assertEquals(currentWeek, lesson.getDisplayDate());
+        Lesson lesson = new LessonBuilder().withDate(DATE_ONE_WEEK_AGO).buildRecurring();
+        assertEquals(DATE_CURRENT_WEEK, lesson.getDisplayDate());
         assertEquals(LocalDate.now(), lesson.getDisplayLocalDate());
     }
 
     @Test
     public void getDisplayDate_dateOver_showNextUncancelledDate() {
-        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
-        Date dateCurrentWeek = DateUtil.build(LocalDate.now());
-        Date dateOneWeekLater = DateUtil.build(LocalDate.now().plusWeeks(1));
-        Lesson lesson = new LessonBuilder().withDate(dateOneWeekAgo)
-                .withCancelledDatesSet(dateCurrentWeek).buildRecurring();
-
-        assertEquals(dateOneWeekLater, lesson.getDisplayDate());
+        Lesson lesson = new LessonBuilder().withDate(DATE_ONE_WEEK_AGO)
+                .withCancelledDatesSet(DATE_CURRENT_WEEK).buildRecurring();
+        assertEquals(DATE_ONE_WEEK_LATER, lesson.getDisplayDate());
         assertEquals(LocalDate.now().plusWeeks(1), lesson.getDisplayLocalDate());
     }
+
+    @Test
+    public void getDisplayStartLocalDateTime_dateNotOver_sameDateTime() {
+        Lesson lesson = new LessonBuilder().withDate(DATE_CURRENT_WEEK)
+                .withTimeRange(VALID_TIME_RANGE).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+        assertEquals(timeRange.getStart().atDate(DATE_CURRENT_WEEK.getLocalDate()),
+                lesson.getDisplayStartLocalDateTime());
+    }
+
+    @Test
+    public void getDisplayStartLocalDateTime_dateOver_showNextDateTime() {
+        Lesson lesson = new LessonBuilder().withDate(DATE_ONE_WEEK_AGO)
+                .withTimeRange(VALID_TIME_RANGE).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+        assertEquals(timeRange.getStart().atDate(DATE_CURRENT_WEEK.getLocalDate()),
+                lesson.getDisplayStartLocalDateTime());
+    }
+
+    @Test
+    public void getDisplayStartLocalDateTime_dateOver_showNextUncancelledDateTime() {
+        Lesson lesson = new LessonBuilder().withDate(DATE_ONE_WEEK_AGO).withTimeRange(VALID_TIME_RANGE)
+                .withCancelledDatesSet(DATE_CURRENT_WEEK).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+        assertEquals(timeRange.getStart().atDate(DATE_ONE_WEEK_LATER.getLocalDate()),
+                lesson.getDisplayStartLocalDateTime());
+    }
+
+    @Test
+    public void getDisplayEndLocalDateTime_dateNotOver_sameDateTime() {
+        Lesson lesson = new LessonBuilder().withDate(DATE_CURRENT_WEEK)
+                .withTimeRange(VALID_TIME_RANGE).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+        assertEquals(timeRange.getEnd().atDate(DATE_CURRENT_WEEK.getLocalDate()),
+                lesson.getDisplayEndLocalDateTime());
+    }
+
+    @Test
+    public void getDisplayEndLocalDateTime_dateOver_showNextDateTime() {
+        Lesson lesson = new LessonBuilder().withDate(DATE_ONE_WEEK_AGO)
+                .withTimeRange(VALID_TIME_RANGE).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+        assertEquals(timeRange.getEnd().atDate(DATE_CURRENT_WEEK.getLocalDate()),
+                lesson.getDisplayEndLocalDateTime());
+    }
+
+    @Test
+    public void getDisplayEndLocalDateTime_dateOver_showNextUncancelledDateTime() {
+        Lesson lesson = new LessonBuilder().withDate(DATE_ONE_WEEK_AGO).withTimeRange(VALID_TIME_RANGE)
+                .withCancelledDatesSet(DATE_CURRENT_WEEK).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+        assertEquals(timeRange.getEnd().atDate(DATE_ONE_WEEK_LATER.getLocalDate()),
+                lesson.getDisplayEndLocalDateTime());
+    }
+
 
     @Test
     public void isClashing_withMakeupLesson_returnsTrue() {
         // clashes with makeup lesson with clashing day and time
         Lesson recurringLesson = new LessonBuilder().withDate(VALID_DATE_MON).buildRecurring();
         Lesson makeupLesson = new LessonBuilder().withDate(VALID_DATE_NEXT_MON).build();
-
         assertTrue(recurringLesson.isClashing(makeupLesson));
     }
 
     @Test
-    public void getDisplayStartLocalDateTime_dateNotOver_sameDate() {
-        Date dateCurrentWeek = DateUtil.build(LocalDate.now());
-        Lesson lesson = new LessonBuilder().withDate(dateCurrentWeek).withTimeRange(VALID_TIME_RANGE).buildRecurring();
-        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
-        assertEquals(timeRange.getStart().atDate(dateCurrentWeek.getLocalDate()),
-                lesson.getDisplayStartLocalDateTime());
-    }
-
-    @Test
-    public void getDisplayStartLocalDateTime_dateOver_showNextDate() {
-        Date currentWeek = DateUtil.build(LocalDate.now());
-        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
-        Lesson lesson = new LessonBuilder().withDate(dateOneWeekAgo).withTimeRange(VALID_TIME_RANGE).buildRecurring();
-        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
-        assertEquals(timeRange.getStart().atDate(currentWeek.getLocalDate()),
-                lesson.getDisplayStartLocalDateTime());
-    }
-
-    @Test
-    public void getDisplayStartLocalDateTime_dateOver_showNextUncancelledDate() {
-        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
-        Date dateCurrentWeek = DateUtil.build(LocalDate.now());
-        Date dateOneWeekLater = DateUtil.build(LocalDate.now().plusWeeks(1));
-        Lesson lesson = new LessonBuilder().withDate(dateOneWeekAgo).withTimeRange(VALID_TIME_RANGE)
-                .withCancelledDatesSet(dateCurrentWeek).buildRecurring();
-        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
-
-        assertEquals(timeRange.getStart().atDate(dateOneWeekLater.getLocalDate()),
-                lesson.getDisplayStartLocalDateTime());
-    }
-
-    @Test
-    public void getDisplayEndLocalDateTime_dateNotOver_sameDate() {
-        Date dateCurrentWeek = DateUtil.build(LocalDate.now());
-        Lesson lesson = new LessonBuilder().withDate(dateCurrentWeek).withTimeRange(VALID_TIME_RANGE).buildRecurring();
-        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
-        assertEquals(timeRange.getEnd().atDate(dateCurrentWeek.getLocalDate()),
-                lesson.getDisplayEndLocalDateTime());
-    }
-
-    @Test
-    public void getDisplayEndLocalDateTime_dateOver_showNextDate() {
-        Date currentWeek = DateUtil.build(LocalDate.now());
-        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
-        Lesson lesson = new LessonBuilder().withDate(dateOneWeekAgo).withTimeRange(VALID_TIME_RANGE).buildRecurring();
-        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
-        assertEquals(timeRange.getEnd().atDate(currentWeek.getLocalDate()),
-                lesson.getDisplayEndLocalDateTime());
-    }
-
-    @Test
-    public void getDisplayEndLocalDateTime_dateOver_showNextUncancelledDate() {
-        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
-        Date dateCurrentWeek = DateUtil.build(LocalDate.now());
-        Date dateOneWeekLater = DateUtil.build(LocalDate.now().plusWeeks(1));
-        Lesson lesson = new LessonBuilder().withDate(dateOneWeekAgo).withTimeRange(VALID_TIME_RANGE)
-                .withCancelledDatesSet(dateCurrentWeek).buildRecurring();
-        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
-
-        assertEquals(timeRange.getEnd().atDate(dateOneWeekLater.getLocalDate()),
-                lesson.getDisplayEndLocalDateTime());
-    }
-
-    @Test
-    public void isClashing_withMakeupLessonD_returnsFalse() {
+    public void isClashing_withMakeupLesson_returnsFalse() {
         // does not clash with makeup lesson on same day and non-clashing time
         Lesson recurringLesson = new LessonBuilder().withTimeRange(VALID_TIME_RANGE).buildRecurring();
         Lesson makeupLesson = new LessonBuilder().withTimeRange(VALID_NON_CLASHING_TIME_RANGE).build();
-
         assertFalse(recurringLesson.isClashing(makeupLesson));
     }
 
@@ -235,7 +220,6 @@ class RecurringLessonTest {
         Lesson recurringLesson = new LessonBuilder().withDate(VALID_DATE_MON).withTimeRange(VALID_TIME_RANGE)
                 .buildRecurring();
         Date date = new Date(VALID_DATE_NEXT_MON);
-
         assertTrue(recurringLesson.hasLessonOnDate(date));
     }
 
@@ -245,13 +229,12 @@ class RecurringLessonTest {
         Lesson recurringLesson = new LessonBuilder().withDate(VALID_DATE_MON).withTimeRange(VALID_TIME_RANGE)
                 .buildRecurring();
         Date dateTue = new Date(VALID_DATE_TUE);
-
         assertFalse(recurringLesson.hasLessonOnDate(dateTue));
 
         // date lies on a recurring lesson date and is cancelled
         recurringLesson = new LessonBuilder().withDate(VALID_DATE_MON).withTimeRange(VALID_TIME_RANGE)
                 .withCancelledDatesSet(VALID_DATE_NEXT_MON).buildRecurring();
         Date dateMon = new Date(VALID_DATE_NEXT_MON);
-        assertFalse(recurringLesson.hasLessonOnDate(dateTue));
+        assertFalse(recurringLesson.hasLessonOnDate(dateMon));
     }
 }

--- a/src/test/java/seedu/address/model/lesson/RecurringLessonTest.java
+++ b/src/test/java/seedu/address/model/lesson/RecurringLessonTest.java
@@ -66,6 +66,70 @@ class RecurringLessonTest {
     }
 
     @Test
+    public void getDisplayStartLocalDateTime_dateNotOver_sameDate() {
+        Date dateCurrentWeek = DateUtil.build(LocalDate.now());
+        Lesson lesson = new LessonBuilder().withDate(dateCurrentWeek).withTimeRange(VALID_TIME_RANGE).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+        assertEquals(timeRange.getStart().atDate(dateCurrentWeek.getLocalDate()),
+                lesson.getDisplayStartLocalDateTime());
+    }
+
+    @Test
+    public void getDisplayStartLocalDateTime_dateOver_showNextDate() {
+        Date currentWeek = DateUtil.build(LocalDate.now());
+        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
+        Lesson lesson = new LessonBuilder().withDate(dateOneWeekAgo).withTimeRange(VALID_TIME_RANGE).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+        assertEquals(timeRange.getStart().atDate(currentWeek.getLocalDate()),
+                lesson.getDisplayStartLocalDateTime());
+    }
+
+    @Test
+    public void getDisplayStartLocalDateTime_dateOver_showNextUncancelledDate() {
+        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
+        Date dateCurrentWeek = DateUtil.build(LocalDate.now());
+        Date dateOneWeekLater = DateUtil.build(LocalDate.now().plusWeeks(1));
+        Lesson lesson = new LessonBuilder().withDate(dateOneWeekAgo).withTimeRange(VALID_TIME_RANGE)
+                .withCancelledDatesSet(dateCurrentWeek).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+
+        assertEquals(timeRange.getStart().atDate(dateOneWeekLater.getLocalDate()),
+                lesson.getDisplayStartLocalDateTime());
+    }
+
+    @Test
+    public void getDisplayEndLocalDateTime_dateNotOver_sameDate() {
+        Date dateCurrentWeek = DateUtil.build(LocalDate.now());
+        Lesson lesson = new LessonBuilder().withDate(dateCurrentWeek).withTimeRange(VALID_TIME_RANGE).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+        assertEquals(timeRange.getEnd().atDate(dateCurrentWeek.getLocalDate()),
+                lesson.getDisplayEndLocalDateTime());
+    }
+
+    @Test
+    public void getDisplayEndLocalDateTime_dateOver_showNextDate() {
+        Date currentWeek = DateUtil.build(LocalDate.now());
+        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
+        Lesson lesson = new LessonBuilder().withDate(dateOneWeekAgo).withTimeRange(VALID_TIME_RANGE).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+        assertEquals(timeRange.getEnd().atDate(currentWeek.getLocalDate()),
+                lesson.getDisplayEndLocalDateTime());
+    }
+
+    @Test
+    public void getDisplayEndLocalDateTime_dateOver_showNextUncancelledDate() {
+        Date dateOneWeekAgo = DateUtil.build(LocalDate.now().minusWeeks(1));
+        Date dateCurrentWeek = DateUtil.build(LocalDate.now());
+        Date dateOneWeekLater = DateUtil.build(LocalDate.now().plusWeeks(1));
+        Lesson lesson = new LessonBuilder().withDate(dateOneWeekAgo).withTimeRange(VALID_TIME_RANGE)
+                .withCancelledDatesSet(dateCurrentWeek).buildRecurring();
+        TimeRange timeRange = new TimeRange(VALID_TIME_RANGE);
+
+        assertEquals(timeRange.getEnd().atDate(dateOneWeekLater.getLocalDate()),
+                lesson.getDisplayEndLocalDateTime());
+    }
+
+    @Test
     public void isClashing_withMakeupLessonD_returnsFalse() {
         // does not clash with makeup lesson on same day and non-clashing time
         Lesson recurringLesson = new LessonBuilder().withTimeRange(VALID_TIME_RANGE).buildRecurring();

--- a/src/test/java/seedu/address/testutil/TypicalDates.java
+++ b/src/test/java/seedu/address/testutil/TypicalDates.java
@@ -5,7 +5,7 @@ import java.time.LocalDate;
 import seedu.address.model.lesson.Date;
 
 /**
- * A utility class containing a list of {@code Dates} objects to be used in tests.
+ * A utility class containing a list of {@code Date} objects to be used in tests.
  */
 public class TypicalDates {
     public static final Date DATE_CURRENT_WEEK = DateUtil.build(LocalDate.now());

--- a/src/test/java/seedu/address/testutil/TypicalDates.java
+++ b/src/test/java/seedu/address/testutil/TypicalDates.java
@@ -1,8 +1,5 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_NEXT_MON;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_TUE;
-
 import java.time.LocalDate;
 
 import seedu.address.model.lesson.Date;

--- a/src/test/java/seedu/address/testutil/TypicalDates.java
+++ b/src/test/java/seedu/address/testutil/TypicalDates.java
@@ -1,0 +1,18 @@
+package seedu.address.testutil;
+
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_NEXT_MON;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_TUE;
+
+import java.time.LocalDate;
+
+import seedu.address.model.lesson.Date;
+
+/**
+ * A utility class containing a list of {@code Dates} objects to be used in tests.
+ */
+public class TypicalDates {
+    public static final Date DATE_CURRENT_WEEK = DateUtil.build(LocalDate.now());
+    public static final Date DATE_ONE_WEEK_AGO = DateUtil.build(LocalDate.now().minusWeeks(1));
+    public static final Date DATE_ONE_WEEK_LATER = DateUtil.build(LocalDate.now().plusWeeks(1));
+    public static final Date DATE_TWO_WEEKS_LATER = DateUtil.build(LocalDate.now().plusWeeks(2));
+}

--- a/src/test/java/seedu/address/testutil/TypicalTags.java
+++ b/src/test/java/seedu/address/testutil/TypicalTags.java
@@ -1,9 +1,16 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FORGETFUL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_UNPAID;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_ZOOM;
+
 import seedu.address.model.tag.Tag;
 
+/**
+ * A utility class containing a list of {@code Tags} objects to be used in tests.
+ */
 public class TypicalTags {
-    public static final Tag TAG_FORGETFUL = new Tag("forgetful");
-    public static final Tag TAG_UNPAID = new Tag("unpaid");
-    public static final Tag TAG_ZOOM = new Tag("zoom");
+    public static final Tag TAG_FORGETFUL = new Tag(VALID_TAG_FORGETFUL);
+    public static final Tag TAG_UNPAID = new Tag(VALID_TAG_UNPAID);
+    public static final Tag TAG_ZOOM = new Tag(VALID_TAG_ZOOM);
 }

--- a/src/test/java/seedu/address/testutil/TypicalTags.java
+++ b/src/test/java/seedu/address/testutil/TypicalTags.java
@@ -7,7 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_ZOOM;
 import seedu.address.model.tag.Tag;
 
 /**
- * A utility class containing a list of {@code Tags} objects to be used in tests.
+ * A utility class containing a list of {@code Tag} objects to be used in tests.
  */
 public class TypicalTags {
     public static final Tag TAG_FORGETFUL = new Tag(VALID_TAG_FORGETFUL);


### PR DESCRIPTION
// omo I opened the wrong tp folder to create the new branch.

So currently, lessons are considered upcoming by comparing min
For example, date today is 30 Oct 1500

Not upcoming:
1. Date before 30 Oct (has passed)
2. 30 Oct end time before 1500 (has passed)
3. 1 Nov start time after 1500 (beyond 2 days)

Upcoming:
1. 30 Oct end time after or at 1500
2. 31 Oct all day with valid time range
3. 1 Nov start time before or at 1500

Limitation:
- reminder window does not automatically update the list, it only updates when the user keys in `remind` in the command box if no modifications are made to any lesson. (i.e. if the user does nth and just wait for the time to pass, the reminder list does not update upcoming lessons)
- reminder list also updates when `ladd`, `ledit`, `ldelete` are used
 // update on 31 oct 
- allow update with shortcut key and clicking on menu item