### PR TITLE
Fix Undo/Redo Bugs

### DIFF
--- a/src/main/java/seedu/address/logic/UndoRedoStack.java
+++ b/src/main/java/seedu/address/logic/UndoRedoStack.java
@@ -3,9 +3,11 @@ package seedu.address.logic;
 import java.util.Stack;
 
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.UndoableCommand;
 
-//@@author Zhiyuan-Amos-reused
+// @@author Zhiyuan-Amos-reused
 // Reused code from
 // https://github.com/nus-cs2103-AY1718S2/addressbook-level4/
 // blob/master/src/main/java/seedu/address/logic/UndoRedoStack.java
@@ -33,6 +35,9 @@ public class UndoRedoStack {
      * @param command Command executed.
      */
     public void pushUndoableCommand(Command command) {
+        if (!(command instanceof UndoCommand) && !(command instanceof RedoCommand)) {
+            redoStack.clear();
+        }
         if (!(command instanceof UndoableCommand)) {
             return;
         }

--- a/src/main/java/seedu/address/logic/UndoRedoStack.java
+++ b/src/main/java/seedu/address/logic/UndoRedoStack.java
@@ -3,8 +3,6 @@ package seedu.address.logic;
 import java.util.Stack;
 
 import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.RedoCommand;
-import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.UndoableCommand;
 
 // @@author Zhiyuan-Amos-reused
@@ -31,16 +29,15 @@ public class UndoRedoStack {
 
     /**
      * Adds Command to Undo Stack if command is undoable.
+     * Clears the redo-stack
      *
      * @param command Command executed.
      */
     public void pushUndoableCommand(Command command) {
-        if (!(command instanceof UndoCommand) && !(command instanceof RedoCommand)) {
-            redoStack.clear();
-        }
         if (!(command instanceof UndoableCommand)) {
             return;
         }
+        redoStack.clear();
 
         undoStack.push((UndoableCommand) command);
     }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -87,7 +87,7 @@ public class AddCommand extends UndoableCommand {
         }
 
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), toAdd);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -92,21 +92,21 @@ public class AddCommand extends UndoableCommand {
      * To undo add student, delete added student
      */
     @Override
-    protected void undo() {
+    protected Person undo() throws AssertionError {
         requireNonNull(model);
 
+        checkValidity(toAdd);
+
         model.deletePerson(toAdd);
+        return null;
     }
 
     @Override
-    protected void redo() {
+    protected Person redo() {
         requireNonNull(model);
 
-        try {
-            executeUndoableCommand();
-        } catch (CommandException ce) {
-            throw new AssertionError(MESSAGE_REDO_FAILURE);
-        }
+        model.addPerson(toAdd);
+        return toAdd;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -72,7 +72,9 @@ public class AddCommand extends UndoableCommand {
      * Creates an AddCommand to add the specified {@code Person}
      */
     public AddCommand(Person person) {
+        super(COMMAND_ACTION);
         requireNonNull(person);
+
         toAdd = person;
     }
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -21,6 +21,10 @@ public class ClearCommand extends UndoableCommand {
 
     private ReadOnlyAddressBook previousAddressBook;
 
+    public ClearCommand() {
+        super(COMMAND_ACTION);
+    }
+
     @Override
     public CommandResult executeUndoableCommand() {
         requireNonNull(model);

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Person;
 
 /**
  * Clears the address book.
@@ -29,10 +30,11 @@ public class ClearCommand extends UndoableCommand {
     }
 
     @Override
-    protected void undo() {
+    protected Person undo() {
         requireNonNull(model);
 
         model.setAddressBook(previousAddressBook);
+        return null;
     }
 
     /**
@@ -40,9 +42,10 @@ public class ClearCommand extends UndoableCommand {
      * {@code previousAddressBook} becomes an empty address book.
      */
     @Override
-    protected void redo() {
+    protected Person redo() {
         requireNonNull(model);
 
-        executeUndoableCommand();
+        model.setAddressBook(new AddressBook());
+        return null;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -39,7 +39,11 @@ public class DeleteCommand extends UndoableCommand {
 
     private Person deletedPerson;
 
+    /**
+     * Constructs a Delete Command.
+     */
     public DeleteCommand(Index targetIndex) {
+        super(COMMAND_ACTION);
         this.targetIndex = targetIndex;
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -35,7 +35,7 @@ public class DeleteCommand extends UndoableCommand {
 
     public static final String MESSAGE_DELETE_STUDENT_SUCCESS = "Deleted student: %1$s";
 
-    private final Index targetIndex;
+    private Index targetIndex;
 
     private Person deletedPerson;
 
@@ -49,27 +49,30 @@ public class DeleteCommand extends UndoableCommand {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         Person personToDelete = CommandUtil.getPerson(lastShownList, targetIndex);
+
+        targetIndex = setToDefinitiveIndex(personToDelete);
+
         model.deletePerson(personToDelete);
         deletedPerson = personToDelete;
         return new CommandResult(String.format(MESSAGE_DELETE_STUDENT_SUCCESS, personToDelete));
     }
 
     @Override
-    protected void undo() {
+    protected Person undo() {
         requireNonNull(model);
 
         model.addPersonAtIndex(deletedPerson, targetIndex);
+        return deletedPerson;
     }
 
     @Override
-    protected void redo() {
+    protected Person redo() {
         requireNonNull(model);
 
-        try {
-            executeUndoableCommand();
-        } catch (CommandException ce) {
-            throw new AssertionError(MESSAGE_REDO_FAILURE);
-        }
+        checkValidity(deletedPerson);
+
+        model.deletePerson(deletedPerson);
+        return deletedPerson;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -12,7 +12,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHOOL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -111,8 +111,7 @@ public class EditCommand extends UndoableCommand {
         }
 
         model.setPerson(personBeforeEdit, personAfterEdit);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_STUDENT_SUCCESS, personAfterEdit));
+        return new CommandResult(String.format(MESSAGE_EDIT_STUDENT_SUCCESS, personAfterEdit), personAfterEdit);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -86,6 +86,7 @@ public class EditCommand extends UndoableCommand {
      * @param editPersonDescriptor details to edit the person with
      */
     public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+        super(COMMAND_ACTION);
         requireNonNull(index);
         requireNonNull(editPersonDescriptor);
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -99,6 +99,7 @@ public class EditCommand extends UndoableCommand {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         personBeforeEdit = CommandUtil.getPerson(lastShownList, index);
+
         personAfterEdit = createEditedPerson(personBeforeEdit, editPersonDescriptor);
 
         if (!personBeforeEdit.isSamePerson(personAfterEdit) && model.hasPerson(personAfterEdit)) {
@@ -140,21 +141,22 @@ public class EditCommand extends UndoableCommand {
     }
 
     @Override
-    public void undo() {
+    public Person undo() {
         requireNonNull(model);
 
+        checkValidity(personAfterEdit);
+
         model.setPerson(personAfterEdit, personBeforeEdit);
+        return personBeforeEdit;
     }
 
     @Override
-    protected void redo() {
+    protected Person redo() {
         requireNonNull(model);
 
-        try {
-            executeUndoableCommand();
-        } catch (CommandException ce) {
-            throw new AssertionError(MESSAGE_REDO_FAILURE);
-        }
+        checkValidity(personBeforeEdit);
+        model.setPerson(personBeforeEdit, personAfterEdit);
+        return personAfterEdit;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/LessonAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LessonAddCommand.java
@@ -75,7 +75,7 @@ public class LessonAddCommand extends UndoableCommand {
             + "You can specify the start date with " + PREFIX_DATE + "DATE and the end date with "
             + PREFIX_RECURRING + "END_DATE";
 
-    private final Index index;
+    private Index index;
     private final Lesson toAdd;
     private Person personBeforeLessonAdd;
     private Person personAfterLessonAdd;
@@ -95,6 +95,7 @@ public class LessonAddCommand extends UndoableCommand {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         personBeforeLessonAdd = CommandUtil.getPerson(lastShownList, index);
+
         Set<Lesson> lessons = personBeforeLessonAdd.getLessons();
         Set<Lesson> updatedLessons = createUpdatedLessons(lessons, toAdd);
         personAfterLessonAdd = PersonUtil.createdEditedPerson(personBeforeLessonAdd, updatedLessons);
@@ -130,21 +131,23 @@ public class LessonAddCommand extends UndoableCommand {
     }
 
     @Override
-    protected void undo() {
+    protected Person undo() throws AssertionError {
         requireNonNull(model);
 
+        checkValidity(personAfterLessonAdd);
+
         model.setPerson(personAfterLessonAdd, personBeforeLessonAdd);
+        return personBeforeLessonAdd;
     }
 
     @Override
-    protected void redo() {
+    protected Person redo() {
         requireNonNull(model);
 
-        try {
-            executeUndoableCommand();
-        } catch (CommandException ce) {
-            throw new AssertionError(MESSAGE_REDO_FAILURE);
-        }
+        checkValidity(personBeforeLessonAdd);
+
+        model.setPerson(personBeforeLessonAdd, personAfterLessonAdd);
+        return personAfterLessonAdd;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/LessonAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LessonAddCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_RATES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RECURRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 import java.util.Set;
@@ -84,6 +83,7 @@ public class LessonAddCommand extends UndoableCommand {
      * Creates a LessonAddCommand to add the specified {@code Lesson}
      */
     public LessonAddCommand(Index index, Lesson lesson) {
+        super(COMMAND_ACTION);
         requireNonNull(lesson);
         this.index = index;
         toAdd = lesson;

--- a/src/main/java/seedu/address/logic/commands/LessonAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LessonAddCommand.java
@@ -101,7 +101,6 @@ public class LessonAddCommand extends UndoableCommand {
         personAfterLessonAdd = PersonUtil.createdEditedPerson(personBeforeLessonAdd, updatedLessons);
 
         model.setPerson(personBeforeLessonAdd, personAfterLessonAdd);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_ADD_LESSON_SUCCESS, personAfterLessonAdd.getName(), toAdd),
                 personAfterLessonAdd);
     }

--- a/src/main/java/seedu/address/logic/commands/LessonDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LessonDeleteCommand.java
@@ -71,7 +71,6 @@ public class LessonDeleteCommand extends UndoableCommand {
         personAfterLessonDelete = PersonUtil.createdEditedPerson(personBeforeLessonDelete, updatedLessons);
 
         model.setPerson(personBeforeLessonDelete, personAfterLessonDelete);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_DELETE_LESSON_SUCCESS,
                 personAfterLessonDelete.getName(), toRemove), personAfterLessonDelete);
     }

--- a/src/main/java/seedu/address/logic/commands/LessonDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LessonDeleteCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,6 +47,8 @@ public class LessonDeleteCommand extends UndoableCommand {
      * @param index of the person in the filtered person list to delete lesson from
      */
     public LessonDeleteCommand(Index index, Index lessonIndex) {
+        super(COMMAND_ACTION);
+
         requireNonNull(index);
         requireNonNull(lessonIndex);
         this.index = index;

--- a/src/main/java/seedu/address/logic/commands/LessonDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LessonDeleteCommand.java
@@ -39,7 +39,7 @@ public class LessonDeleteCommand extends UndoableCommand {
 
     public static final String MESSAGE_DELETE_LESSON_SUCCESS = "Deleted Lesson for student %1$s:\n%2$s";
 
-    private final Index index;
+    private Index index;
     private final Index lessonIndex;
     private Person personBeforeLessonDelete;
     private Person personAfterLessonDelete;
@@ -60,6 +60,9 @@ public class LessonDeleteCommand extends UndoableCommand {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         personBeforeLessonDelete = CommandUtil.getPerson(lastShownList, index);
+
+        // set with index from mainList
+        index = setToDefinitiveIndex(personBeforeLessonDelete);
 
         List<Lesson> lessonList = new ArrayList<>(personBeforeLessonDelete.getLessons());
         Lesson toRemove = CommandUtil.getLesson(lessonList, lessonIndex);
@@ -89,21 +92,23 @@ public class LessonDeleteCommand extends UndoableCommand {
     }
 
     @Override
-    protected void undo() {
+    protected Person undo() throws AssertionError {
         requireNonNull(model);
 
+        checkValidity(personAfterLessonDelete);
+
         model.setPerson(personAfterLessonDelete, personBeforeLessonDelete);
+        return personBeforeLessonDelete;
     }
 
     @Override
-    protected void redo() {
+    protected Person redo() throws AssertionError {
         requireNonNull(model);
 
-        try {
-            executeUndoableCommand();
-        } catch (CommandException ce) {
-            throw new AssertionError(MESSAGE_REDO_FAILURE);
-        }
+        checkValidity(personBeforeLessonDelete);
+
+        model.setPerson(personBeforeLessonDelete, personAfterLessonDelete);
+        return personAfterLessonDelete;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/LessonEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LessonEditCommand.java
@@ -131,7 +131,6 @@ public class LessonEditCommand extends UndoableCommand {
         personAfterLessonEdit = PersonUtil.createdEditedPerson(personBeforeLessonEdit, updatedLessons);
 
         model.setPerson(personBeforeLessonEdit, personAfterLessonEdit);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(
                 String.format(MESSAGE_EDIT_LESSON_SUCCESS, personAfterLessonEdit.getName(), lessonToEdit, editedLesson),
                 personAfterLessonEdit);

--- a/src/main/java/seedu/address/logic/commands/LessonEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LessonEditCommand.java
@@ -88,7 +88,7 @@ public class LessonEditCommand extends UndoableCommand {
             "Failed to uncancel lesson! This lesson does not have a cancelled lesson on %1$s.";
 
 
-    private final Index index;
+    private Index index;
     private final Index lessonIndex;
     private final EditLessonDescriptor editLessonDescriptor;
     private Person personBeforeLessonEdit;
@@ -115,6 +115,8 @@ public class LessonEditCommand extends UndoableCommand {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         personBeforeLessonEdit = CommandUtil.getPerson(lastShownList, index);
+
+        index = setToDefinitiveIndex(personBeforeLessonEdit);
 
         List<Lesson> lessonList = personBeforeLessonEdit.getLessons().stream().sorted().collect(Collectors.toList());
         Lesson lessonToEdit = CommandUtil.getLesson(lessonList, lessonIndex);
@@ -265,22 +267,19 @@ public class LessonEditCommand extends UndoableCommand {
     }
 
     @Override
-    protected void undo() {
+    protected Person undo() {
         requireNonNull(model);
 
         model.setPerson(personAfterLessonEdit, personBeforeLessonEdit);
+        return personBeforeLessonEdit;
     }
 
     @Override
-    protected void redo() {
+    protected Person redo() {
         requireNonNull(model);
 
-        try {
-            executeUndoableCommand();
-        } catch (CommandException ce) {
-            throw new AssertionError(MESSAGE_REDO_FAILURE);
-        }
-
+        model.setPerson(personBeforeLessonEdit, personAfterLessonEdit);
+        return personAfterLessonEdit;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/LessonEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LessonEditCommand.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_RECURRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_UNCANCEL;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -101,6 +100,7 @@ public class LessonEditCommand extends UndoableCommand {
      * @param lessonIndex to edit.
      */
     public LessonEditCommand(Index index, Index lessonIndex, EditLessonDescriptor editLessonDescriptor) {
+        super(COMMAND_ACTION);
         requireNonNull(index);
         requireNonNull(lessonIndex);
 
@@ -115,8 +115,6 @@ public class LessonEditCommand extends UndoableCommand {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         personBeforeLessonEdit = CommandUtil.getPerson(lastShownList, index);
-
-        index = setToDefinitiveIndex(personBeforeLessonEdit);
 
         List<Lesson> lessonList = personBeforeLessonEdit.getLessons().stream().sorted().collect(Collectors.toList());
         Lesson lessonToEdit = CommandUtil.getLesson(lessonList, lessonIndex);

--- a/src/main/java/seedu/address/logic/commands/PaidCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PaidCommand.java
@@ -95,7 +95,6 @@ public class PaidCommand extends UndoableCommand {
         personAfterLessonPaid = createEditedPerson(personBeforeLessonPaid, toPay, paidLesson);
 
         model.setPerson(personBeforeLessonPaid, personAfterLessonPaid);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_PAID_LESSON_SUCCESS, personAfterLessonPaid.getName(),
                 toPay, paidLesson), personAfterLessonPaid);
     }

--- a/src/main/java/seedu/address/logic/commands/PaidCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PaidCommand.java
@@ -88,7 +88,6 @@ public class PaidCommand extends UndoableCommand {
             throw new CommandException(Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX);
         }
 
-
         List<Lesson> lessonList = new ArrayList<>(lessons);
         Lesson toPay = lessonList.get(indexToEdit.getZeroBased());
         Lesson paidLesson = createEditedLesson(toPay, payment);
@@ -145,22 +144,23 @@ public class PaidCommand extends UndoableCommand {
     }
 
     @Override
-    protected void undo() {
+    protected Person undo() {
         requireNonNull(model);
 
+        checkValidity(personAfterLessonPaid);
+
         model.setPerson(personAfterLessonPaid, personBeforeLessonPaid);
+        return personBeforeLessonPaid;
     }
 
     @Override
-    protected void redo() {
+    protected Person redo() {
         requireNonNull(model);
 
-        try {
-            executeUndoableCommand();
-        } catch (CommandException ce) {
-            throw new AssertionError(MESSAGE_REDO_FAILURE);
-        }
+        checkValidity(personBeforeLessonPaid);
 
+        model.setPerson(personBeforeLessonPaid, personAfterLessonPaid);
+        return personAfterLessonPaid;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/PaidCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PaidCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAID_AMOUNT;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,6 +64,7 @@ public class PaidCommand extends UndoableCommand {
      * @param payment amount to the lesson.
      */
     public PaidCommand(Index index, Index indexToEdit, Money payment) {
+        super(COMMAND_ACTION);
         requireAllNonNull(index, indexToEdit, payment);
 
         this.index = index;

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.logic.UndoRedoStack;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -25,6 +26,10 @@ public class RedoCommand extends Command {
 
         UndoableCommand commandToRedo = undoRedoStack.popRedo();
         Person studentModified = commandToRedo.redo();
+
+        if (studentModified != null && !model.getFilteredPersonList().contains(studentModified)) {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        }
 
         if (commandToRedo.commandType.equals(ClearCommand.COMMAND_ACTION)
                 || commandToRedo.commandType.equals(DeleteCommand.COMMAND_ACTION)) {

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -12,7 +12,7 @@ public class RedoCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Redoes the last Command that has been undone. \n";
 
-    public static final String MESSAGE_SUCCESS = "Redo success!";
+    public static final String MESSAGE_SUCCESS = "%1$s command for %2$s has been redone.";
     public static final String MESSAGE_FAILURE = "No commands to redo!";
 
     @Override
@@ -23,8 +23,17 @@ public class RedoCommand extends Command {
             throw new CommandException(MESSAGE_FAILURE);
         }
 
-        Person studentModified = undoRedoStack.popRedo().redo();
-        return new CommandResult(MESSAGE_SUCCESS, studentModified);
+        UndoableCommand commandToRedo = undoRedoStack.popRedo();
+        Person studentModified = commandToRedo.redo();
+
+        if (commandToRedo.commandType.equals(ClearCommand.COMMAND_ACTION)
+                || commandToRedo.commandType.equals(DeleteCommand.COMMAND_ACTION)) {
+            String successMessage = commandToRedo.commandType + " command has been redone.";
+            return new CommandResult(successMessage);
+        }
+
+        String successMessage = String.format(MESSAGE_SUCCESS, commandToRedo.commandType, studentModified.getName());
+        return new CommandResult(successMessage, studentModified);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -27,12 +27,14 @@ public class RedoCommand extends Command {
         UndoableCommand commandToRedo = undoRedoStack.popRedo();
         Person studentModified = commandToRedo.redo();
 
-        if (studentModified != null && !model.getFilteredPersonList().contains(studentModified)) {
+        if (studentModified != null && !model.hasPersonFilteredList(studentModified)) {
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         }
 
-        if (commandToRedo.commandType.equals(ClearCommand.COMMAND_ACTION)
-                || commandToRedo.commandType.equals(DeleteCommand.COMMAND_ACTION)) {
+        boolean isClearOrDelete = commandToRedo.commandType.equals(ClearCommand.COMMAND_ACTION)
+                || commandToRedo.commandType.equals(DeleteCommand.COMMAND_ACTION);
+
+        if (isClearOrDelete) {
             String successMessage = commandToRedo.commandType + " command has been redone.";
             return new CommandResult(successMessage);
         }

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -31,10 +31,7 @@ public class RedoCommand extends Command {
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         }
 
-        boolean isClearOrDelete = commandToRedo.commandType.equals(ClearCommand.COMMAND_ACTION)
-                || commandToRedo.commandType.equals(DeleteCommand.COMMAND_ACTION);
-
-        if (isClearOrDelete) {
+        if (commandToRedo.isClearOrDelete()) {
             String successMessage = commandToRedo.commandType + " command has been redone.";
             return new CommandResult(successMessage);
         }

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.logic.UndoRedoStack;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 
 public class RedoCommand extends Command {
     public static final String COMMAND_WORD = "redo";
@@ -22,8 +23,8 @@ public class RedoCommand extends Command {
             throw new CommandException(MESSAGE_FAILURE);
         }
 
-        undoRedoStack.popRedo().redo();
-        return new CommandResult(MESSAGE_SUCCESS);
+        Person studentModified = undoRedoStack.popRedo().redo();
+        return new CommandResult(MESSAGE_SUCCESS, studentModified);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -34,10 +34,7 @@ public class UndoCommand extends Command {
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         }
 
-        boolean isClearOrAdd = commandToUndo.commandType.equals(ClearCommand.COMMAND_ACTION)
-                || commandToUndo.commandType.equals(AddCommand.COMMAND_ACTION);
-
-        if (isClearOrAdd) {
+        if (commandToUndo.isClearOrAdd()) {
             String successMessage = commandToUndo.commandType + " command has been undone.";
             return new CommandResult(successMessage);
         }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -30,12 +30,14 @@ public class UndoCommand extends Command {
 
         Person studentModified = commandToUndo.undo();
 
-        if (studentModified != null && !model.getFilteredPersonList().contains(studentModified)) {
+        if (studentModified != null && !model.hasPersonFilteredList(studentModified)) {
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         }
 
-        if (commandToUndo.commandType.equals(ClearCommand.COMMAND_ACTION)
-                || commandToUndo.commandType.equals(AddCommand.COMMAND_ACTION)) {
+        boolean isClearOrAdd = commandToUndo.commandType.equals(ClearCommand.COMMAND_ACTION)
+                || commandToUndo.commandType.equals(AddCommand.COMMAND_ACTION);
+
+        if (isClearOrAdd) {
             String successMessage = commandToUndo.commandType + " command has been undone.";
             return new CommandResult(successMessage);
         }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.logic.UndoRedoStack;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -28,6 +29,10 @@ public class UndoCommand extends Command {
         UndoableCommand commandToUndo = undoRedoStack.popUndo();
 
         Person studentModified = commandToUndo.undo();
+
+        if (studentModified != null && !model.getFilteredPersonList().contains(studentModified)) {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        }
 
         if (commandToUndo.commandType.equals(ClearCommand.COMMAND_ACTION)
                 || commandToUndo.commandType.equals(AddCommand.COMMAND_ACTION)) {

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.logic.UndoRedoStack;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 
 public class UndoCommand extends Command {
 
@@ -23,8 +24,8 @@ public class UndoCommand extends Command {
         if (!undoRedoStack.canUndo()) {
             throw new CommandException(MESSAGE_FAILURE);
         }
-        undoRedoStack.popUndo().undo();
-        return new CommandResult(MESSAGE_SUCCESS);
+        Person studentModified = undoRedoStack.popUndo().undo();
+        return new CommandResult(MESSAGE_SUCCESS, studentModified);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -14,7 +14,7 @@ public class UndoCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Undoes the last Command that modified TAB data. \n";
 
-    public static final String MESSAGE_SUCCESS = "Undo success!";
+    public static final String MESSAGE_SUCCESS = "%1$s command for %2$s has been undone.";
     public static final String MESSAGE_FAILURE = "No commands to undo!";
 
     @Override
@@ -24,8 +24,19 @@ public class UndoCommand extends Command {
         if (!undoRedoStack.canUndo()) {
             throw new CommandException(MESSAGE_FAILURE);
         }
-        Person studentModified = undoRedoStack.popUndo().undo();
-        return new CommandResult(MESSAGE_SUCCESS, studentModified);
+
+        UndoableCommand commandToUndo = undoRedoStack.popUndo();
+
+        Person studentModified = commandToUndo.undo();
+
+        if (commandToUndo.commandType.equals(ClearCommand.COMMAND_ACTION)
+                || commandToUndo.commandType.equals(AddCommand.COMMAND_ACTION)) {
+            String successMessage = commandToUndo.commandType + " command has been undone.";
+            return new CommandResult(successMessage);
+        }
+
+        String successMessage = String.format(MESSAGE_SUCCESS, commandToUndo.commandType, studentModified.getName());
+        return new CommandResult(successMessage, studentModified);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -43,4 +43,14 @@ public abstract class UndoableCommand extends Command {
             throw new AssertionError(MESSAGE_FAILURE);
         }
     }
+
+    public boolean isClearOrDelete() {
+        return commandType.equals(ClearCommand.COMMAND_ACTION)
+                || commandType.equals(DeleteCommand.COMMAND_ACTION);
+    }
+
+    public boolean isClearOrAdd() {
+        return commandType.equals(ClearCommand.COMMAND_ACTION)
+                || commandType.equals(AddCommand.COMMAND_ACTION);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -33,7 +33,7 @@ public abstract class UndoableCommand extends Command {
     protected abstract Person redo() throws AssertionError;
 
     protected Index setToDefinitiveIndex(Person personToUndo) {
-        ObservableList<Person> mainList = model.getAddressBook().getPersonList();
+        ObservableList<Person> mainList = model.getUnfilteredPersonList();
         Index definitiveIndex = Index.fromZeroBased(mainList.indexOf(personToUndo));
         return definitiveIndex;
     }

--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -16,6 +16,11 @@ import seedu.address.model.person.Person;
 public abstract class UndoableCommand extends Command {
     public static final String MESSAGE_FAILURE = "The command has been successfully executed previously; "
             + "it should not fail now.";
+    public final String commandType;
+
+    protected UndoableCommand(String commandType) {
+        this.commandType = commandType;
+    }
 
     protected abstract CommandResult executeUndoableCommand() throws CommandException;
 

--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.commands;
 
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.Person;
 
 // Solution adapted from
 // https://github.com/nus-cs2103-AY1718S2/
@@ -11,7 +14,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
  * A command that can be undone or redone
  */
 public abstract class UndoableCommand extends Command {
-    public static final String MESSAGE_REDO_FAILURE = "The command has been successfully executed previously; "
+    public static final String MESSAGE_FAILURE = "The command has been successfully executed previously; "
             + "it should not fail now.";
 
     protected abstract CommandResult executeUndoableCommand() throws CommandException;
@@ -21,6 +24,18 @@ public abstract class UndoableCommand extends Command {
         return executeUndoableCommand();
     }
 
-    protected abstract void undo();
-    protected abstract void redo();
+    protected abstract Person undo() throws AssertionError;
+    protected abstract Person redo() throws AssertionError;
+
+    protected Index setToDefinitiveIndex(Person personToUndo) {
+        ObservableList<Person> mainList = model.getAddressBook().getPersonList();
+        Index definitiveIndex = Index.fromZeroBased(mainList.indexOf(personToUndo));
+        return definitiveIndex;
+    }
+
+    protected void checkValidity(Person person) throws AssertionError {
+        if (!model.hasPerson(person)) {
+            throw new AssertionError(MESSAGE_FAILURE);
+        }
+    }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -87,6 +87,11 @@ public interface Model {
     Set<String> getClashingLessonsString(Lesson lesson, Lesson lessonToIgnore);
 
     /**
+     * Returns the full unfiltered list of students in the address book.
+     */
+    ObservableList<Person> getUnfilteredPersonList();
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */
@@ -132,6 +137,12 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * If person is in the filtered list, return true.
+     * @param person Person to check for.
+     */
+    boolean hasPersonFilteredList(Person person);
 
     /** Returns an immutable Last Updated Date object. */
     LastUpdatedDate getLastUpdatedDate();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -128,6 +128,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public ObservableList<Person> getUnfilteredPersonList() {
+        return addressBook.getPersonList();
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
     }
@@ -194,6 +199,12 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public boolean hasPersonFilteredList(Person person) {
+        requireNonNull(person);
+        return filteredPersons.contains(person);
     }
 
     //=========== Last Updated Accessors =============================================================

--- a/src/test/java/seedu/address/logic/UndoRedoStackTest.java
+++ b/src/test/java/seedu/address/logic/UndoRedoStackTest.java
@@ -202,6 +202,9 @@ class UndoRedoStackTest {
     }
 
     private class DummyUndoableCommand extends UndoableCommand {
+        private DummyUndoableCommand() {
+            super("Dummy");
+        }
         @Override
         public CommandResult executeUndoableCommand() {
             return new CommandResult("");

--- a/src/test/java/seedu/address/logic/UndoRedoStackTest.java
+++ b/src/test/java/seedu/address/logic/UndoRedoStackTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.UndoableCommand;
+import seedu.address.model.person.Person;
 
 
 //Solution adapted from
@@ -206,8 +207,12 @@ class UndoRedoStackTest {
             return new CommandResult("");
         }
         @Override
-        protected void undo() {}
+        protected Person undo() {
+            return null;
+        }
         @Override
-        protected void redo() {}
+        protected Person redo() {
+            return null;
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -135,6 +135,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public ObservableList<Person> getUnfilteredPersonList() {
+            throw new AssertionError(MESSAGE_UNEXPECTED_METHOD_CALL);
+        }
+
+        @Override
         public void addPerson(Person person) {
             throw new AssertionError(MESSAGE_UNEXPECTED_METHOD_CALL);
         }
@@ -211,6 +216,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError(MESSAGE_UNEXPECTED_METHOD_CALL);
+        }
+
+        @Override
+        public boolean hasPersonFilteredList(Person person) {
             throw new AssertionError(MESSAGE_UNEXPECTED_METHOD_CALL);
         }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -88,16 +88,16 @@ public class EditCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
+        Person editedPerson = new PersonBuilder(personInFilteredList).withPhone(VALID_PHONE_BOB).build();
         EditCommand editCommand = prepareEditCommand(INDEX_FIRST_PERSON,
-                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
+                new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_STUDENT_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()),
             editedPerson);
-
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/LessonEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LessonEditCommandTest.java
@@ -163,7 +163,7 @@ class LessonEditCommandTest {
                 formerLesson, editedLesson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()),
+        expectedModel.setPerson(expectedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()),
                 personAfterLessonEdit);
 
         assertCommandSuccess(lessonEditCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/LessonEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LessonEditCommandTest.java
@@ -165,6 +165,7 @@ class LessonEditCommandTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(expectedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()),
                 personAfterLessonEdit);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
 
         assertCommandSuccess(lessonEditCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -212,8 +212,12 @@ class RedoCommandTest {
             return new CommandResult("");
         }
         @Override
-        protected void undo() {}
+        protected Person undo() {
+            return null;
+        }
         @Override
-        protected void redo() {}
+        protected Person redo() {
+            return null;
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.UndoRedoStackTestUtil.assertStackStatus;
 import static seedu.address.logic.UndoRedoStackTestUtil.prepareStack;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.PersonBuilder.DEFAULT_NAME;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_LESSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -36,6 +37,8 @@ class RedoCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel;
     private UndoRedoStack undoRedoStack = new UndoRedoStack();
+    private Person studentModified =
+            DEFAULT_MODEL.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
     @Test
     public void execute_success() {
@@ -44,15 +47,16 @@ class RedoCommandTest {
                 Arrays.asList(dummyUndoableCommandOne, dummyUndoableCommandTwo));
         RedoCommand redoCommand = new RedoCommand();
 
+        String expectedMessage = String.format(RedoCommand.MESSAGE_SUCCESS, "Dummy", DEFAULT_NAME);
         //2 Undoable commands in redo stack
         redoCommand.setDependencies(model, undoRedoStack);
-        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, DEFAULT_MODEL);
+        assertCommandSuccess(redoCommand, model, expectedMessage, DEFAULT_MODEL);
         assertStackStatus(Collections.singletonList(dummyUndoableCommandTwo),
                 Collections.singletonList(dummyUndoableCommandOne), undoRedoStack);
 
         //1 Undoable command in redo stack
         redoCommand.setDependencies(model, undoRedoStack);
-        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, DEFAULT_MODEL);
+        assertCommandSuccess(redoCommand, model, expectedMessage, DEFAULT_MODEL);
         assertStackStatus(Arrays.asList(dummyUndoableCommandTwo, dummyUndoableCommandOne),
                 Collections.emptyList(), undoRedoStack);
     }
@@ -76,8 +80,9 @@ class RedoCommandTest {
         //Check stack after Command executed
         assertStackStatus(Collections.emptyList(), Collections.singletonList(addCommand), undoRedoStack);
 
+        String expectedMessage = String.format(RedoCommand.MESSAGE_SUCCESS, AddCommand.COMMAND_ACTION, DEFAULT_NAME);
         //Redo Add command
-        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModel);
         assertStackStatus(Collections.singletonList(addCommand), Collections.emptyList(), undoRedoStack);
     }
 
@@ -89,8 +94,9 @@ class RedoCommandTest {
         //Check stack after Command executed
         assertStackStatus(Collections.emptyList(), Collections.singletonList(clearCommand), undoRedoStack);
 
+        String expectedMessage = ClearCommand.COMMAND_ACTION + " command has been redone.";
         //Redo Clear Command
-        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModel);
         assertStackStatus(Collections.singletonList(clearCommand), Collections.emptyList(), undoRedoStack);
     }
 
@@ -102,8 +108,9 @@ class RedoCommandTest {
         //Check stack after Delete Command
         assertStackStatus(Collections.emptyList(), Collections.singletonList(deleteCommand), undoRedoStack);
 
+        String expectedMessage = DeleteCommand.COMMAND_ACTION + " command has been redone.";
         //Redo Delete Command
-        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModel);
         assertStackStatus(Collections.singletonList(deleteCommand), Collections.emptyList(), undoRedoStack);
     }
 
@@ -117,10 +124,13 @@ class RedoCommandTest {
         //Check stack after Edit Command
         assertStackStatus(Collections.emptyList(), Collections.singletonList(editCommand), undoRedoStack);
 
+        String expectedMessage = String.format(RedoCommand.MESSAGE_SUCCESS,
+                EditCommand.COMMAND_ACTION, DEFAULT_NAME);
         //Redo Edit Command
-        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModel);
         assertStackStatus(Collections.singletonList(editCommand), Collections.emptyList(), undoRedoStack);
     }
+
 
     @Test
     public void execute_redoLessonAddCommand() {
@@ -131,8 +141,10 @@ class RedoCommandTest {
         //Check stack after Lesson Add
         assertStackStatus(Collections.emptyList(), Collections.singletonList(lessonAddCommand), undoRedoStack);
 
+        String expectedMessage = String.format(RedoCommand.MESSAGE_SUCCESS,
+                LessonAddCommand.COMMAND_ACTION, studentModified.getName());
         //Redo Lesson Add Command
-        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModel);
         assertStackStatus(Collections.singletonList(lessonAddCommand), Collections.emptyList(), undoRedoStack);
     }
 
@@ -150,11 +162,12 @@ class RedoCommandTest {
         //Check stack after Lesson Delete Command
         assertStackStatus(Collections.emptyList(), Collections.singletonList(lessonDeleteCommand), undoRedoStack);
 
+        String expectedMessage = String.format(RedoCommand.MESSAGE_SUCCESS,
+                LessonDeleteCommand.COMMAND_ACTION, studentModified.getName());
         //Redo Lesson Delete Command
-        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModel);
         assertStackStatus(Collections.singletonList(lessonDeleteCommand), Collections.emptyList(), undoRedoStack);
     }
-
 
     private Model snapshotModel() {
         return new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
@@ -206,17 +219,20 @@ class RedoCommandTest {
     }
 
     private class DummyUndoableCommand extends UndoableCommand {
+        private DummyUndoableCommand() {
+            super("Dummy");
+        }
         @Override
         public CommandResult executeUndoableCommand() {
             return new CommandResult("");
         }
         @Override
         protected Person undo() {
-            return null;
+            return new PersonBuilder().build();
         }
         @Override
         protected Person redo() {
-            return null;
+            return new PersonBuilder().build();
         }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -30,7 +30,6 @@ import seedu.address.testutil.PersonBuilder;
 
 class RedoCommandTest {
     private static final Model DEFAULT_MODEL = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private final DummyCommand dummyCommand = new DummyCommand();
     private final DummyUndoableCommand dummyUndoableCommandOne = new DummyUndoableCommand();
     private final DummyUndoableCommand dummyUndoableCommandTwo = new DummyUndoableCommand();
 

--- a/src/test/java/seedu/address/logic/commands/UndoCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandIntegrationTest.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.UndoRedoStackTestUtil.assertStackStatus;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HOMEWORK_TEXTBOOK;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.PersonBuilder.DEFAULT_NAME;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_LESSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -23,6 +24,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.lesson.Lesson;
+import seedu.address.model.lesson.Money;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditLessonDescriptorBuilder;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -37,6 +39,9 @@ class UndoCommandIntegrationTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private UndoRedoStack undoRedoStack = new UndoRedoStack();
+    private Person studentModified =
+            DEFAULT_MODEL.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
 
     @Test
     public void execute_success() {
@@ -44,13 +49,14 @@ class UndoCommandIntegrationTest {
         UndoCommand undoCommand = prepareUndoCommand(Arrays.asList(dummyCommand,
                 dummyUndoableCommandOne, dummyUndoableCommandTwo));
 
+        String expectedMessage = String.format(UndoCommand.MESSAGE_SUCCESS, "Dummy", DEFAULT_NAME);
         //2 Undoable commands already called
-        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, DEFAULT_MODEL);
+        assertCommandSuccess(undoCommand, model, expectedMessage, DEFAULT_MODEL);
         assertStackStatus(Collections.singletonList(dummyUndoableCommandOne),
                 Collections.singletonList(dummyUndoableCommandTwo), undoRedoStack);
 
         //1 Undoable command already called
-        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, DEFAULT_MODEL);
+        assertCommandSuccess(undoCommand, model, expectedMessage, DEFAULT_MODEL);
         assertStackStatus(Collections.emptyList(),
                 Arrays.asList(dummyUndoableCommandTwo, dummyUndoableCommandOne), undoRedoStack);
     }
@@ -77,8 +83,9 @@ class UndoCommandIntegrationTest {
         //Check stack after Add Command executed
         assertStackStatus(Collections.singletonList(addCommand), Collections.emptyList(), undoRedoStack);
 
+        String expectedMessage = AddCommand.COMMAND_ACTION + " command has been undone.";
         //Undo Add Command
-        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, DEFAULT_MODEL);
+        assertCommandSuccess(undoCommand, model, expectedMessage, DEFAULT_MODEL);
         assertStackStatus(Collections.emptyList(), Collections.singletonList(addCommand), undoRedoStack);
     }
 
@@ -90,10 +97,12 @@ class UndoCommandIntegrationTest {
         //Check stack after Clear Command
         assertStackStatus(Collections.singletonList(clearCommand), Collections.emptyList(), undoRedoStack);
 
+        String expectedMessage = ClearCommand.COMMAND_ACTION + " command has been undone.";
         //Undo Clear Command
-        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, DEFAULT_MODEL);
+        assertCommandSuccess(undoCommand, model, expectedMessage, DEFAULT_MODEL);
         assertStackStatus(Collections.emptyList(), Collections.singletonList(clearCommand), undoRedoStack);
     }
+
 
     @Test
     public void execute_undoDeleteCommand() {
@@ -103,8 +112,10 @@ class UndoCommandIntegrationTest {
         //Check stack after Delete Command
         assertStackStatus(Collections.singletonList(deleteCommand), Collections.emptyList(), undoRedoStack);
 
+        String expectedMessage = String.format(UndoCommand.MESSAGE_SUCCESS,
+                DeleteCommand.COMMAND_ACTION, studentModified.getName());
         //Undo Delete Command
-        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, DEFAULT_MODEL);
+        assertCommandSuccess(undoCommand, model, expectedMessage, DEFAULT_MODEL);
         assertStackStatus(Collections.emptyList(), Collections.singletonList(deleteCommand), undoRedoStack);
     }
 
@@ -118,8 +129,10 @@ class UndoCommandIntegrationTest {
         //Check stack after Edit Command
         assertStackStatus(Collections.singletonList(editCommand), Collections.emptyList(), undoRedoStack);
 
+        String expectedMessage = String.format(UndoCommand.MESSAGE_SUCCESS,
+                EditCommand.COMMAND_ACTION, studentModified.getName());
         //Undo Edit Command
-        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, DEFAULT_MODEL);
+        assertCommandSuccess(undoCommand, model, expectedMessage, DEFAULT_MODEL);
         assertStackStatus(Collections.emptyList(), Collections.singletonList(editCommand), undoRedoStack);
     }
 
@@ -132,8 +145,10 @@ class UndoCommandIntegrationTest {
         //Check stack after Lesson Add
         assertStackStatus(Collections.singletonList(lessonAddCommand), Collections.emptyList(), undoRedoStack);
 
+        String expectedMessage = String.format(UndoCommand.MESSAGE_SUCCESS,
+                LessonAddCommand.COMMAND_ACTION, studentModified.getName());
         //Undo Lesson Add Command
-        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, DEFAULT_MODEL);
+        assertCommandSuccess(undoCommand, model, expectedMessage, DEFAULT_MODEL);
         assertStackStatus(Collections.emptyList(), Collections.singletonList(lessonAddCommand), undoRedoStack);
     }
 
@@ -155,8 +170,10 @@ class UndoCommandIntegrationTest {
         //Check stack after Lesson Edit
         assertStackStatus(Collections.singletonList(lessonEditCommand), Collections.emptyList(), undoRedoStack);
 
+        String expectedMessage = String.format(UndoCommand.MESSAGE_SUCCESS,
+                LessonEditCommand.COMMAND_ACTION, studentModified.getName());
         //Undo Lesson Add Command
-        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(undoCommand, model, expectedMessage, expectedModel);
         assertStackStatus(Collections.emptyList(), Collections.singletonList(lessonEditCommand), undoRedoStack);
     }
 
@@ -175,9 +192,33 @@ class UndoCommandIntegrationTest {
         //Check stack after Lesson Delete Command
         assertStackStatus(Collections.singletonList(lessonDeleteCommand), Collections.emptyList(), undoRedoStack);
 
+        String expectedMessage = String.format(UndoCommand.MESSAGE_SUCCESS,
+                LessonDeleteCommand.COMMAND_ACTION, studentModified.getName());
         //Undo Lesson Delete Command
-        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(undoCommand, model, expectedMessage, expectedModel);
         assertStackStatus(Collections.emptyList(), Collections.singletonList(lessonDeleteCommand), undoRedoStack);
+    }
+
+    @Test
+    public void execute_undoPaidCommand() {
+        //Add lesson to first student
+        Lesson lesson = new LessonBuilder().withOutstandingFees("100").build();
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withLessons(lesson).build();
+        model.setPerson(firstPerson, editedPerson);
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        PaidCommand paidCommand = new PaidCommand(INDEX_FIRST_PERSON, INDEX_FIRST_LESSON, new Money("20"));
+        UndoCommand undoCommand = prepareUndoCommand(Collections.singletonList(paidCommand));
+
+        //Check stack after Lesson Delete Command
+        assertStackStatus(Collections.singletonList(paidCommand), Collections.emptyList(), undoRedoStack);
+
+        String expectedMessage = String.format(UndoCommand.MESSAGE_SUCCESS,
+                PaidCommand.COMMAND_ACTION, studentModified.getName());
+        //Undo Lesson Delete Command
+        assertCommandSuccess(undoCommand, model, expectedMessage, expectedModel);
+        assertStackStatus(Collections.emptyList(), Collections.singletonList(paidCommand), undoRedoStack);
     }
 
     private UndoCommand prepareUndoCommand(List<Command> commandsBeforeUndo) {
@@ -206,17 +247,20 @@ class UndoCommandIntegrationTest {
     }
 
     private class DummyUndoableCommand extends UndoableCommand {
+        private DummyUndoableCommand() {
+            super("Dummy");
+        }
         @Override
         public CommandResult executeUndoableCommand() {
             return new CommandResult("");
         }
         @Override
         protected Person undo() {
-            return null;
+            return new PersonBuilder().build();
         }
         @Override
         protected Person redo() {
-            return null;
+            return new PersonBuilder().build();
         }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UndoCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandIntegrationTest.java
@@ -211,8 +211,12 @@ class UndoCommandIntegrationTest {
             return new CommandResult("");
         }
         @Override
-        protected void undo() {}
+        protected Person undo() {
+            return null;
+        }
         @Override
-        protected void redo() {}
+        protected Person redo() {
+            return null;
+        }
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -31,7 +31,6 @@ public class PersonBuilder {
     public static final String DEFAULT_SCHOOL = "";
     public static final String DEFAULT_ACAD_STREAM = "";
     public static final String DEFAULT_ACAD_LEVEL = "";
-    public static final String DEFAULT_FEE = "";
     public static final String DEFAULT_REMARK = "";
 
     private Name name;


### PR DESCRIPTION
- [x] Remains on filtered list after every command except add command #267 #240 #251 #259 
- [x] Undo and Redo will not mix up lists #259 #265 #265 
- [x] Detailed Messages of which command type was undone for which student #129

**Note:**
I don't quite get the implementation of `LessonEditTest#execute_filteredList_success`  but it is not passing. What happens now is that the expectedModel's filteredList is the unfilteredList whereas the actual model's filteredList is just the filtered student.
The thing is I am not sure where in the code was the model filtered.