### PR TITLE
Fix bugs with lesson ordering

### DIFF
--- a/src/main/java/seedu/address/model/lesson/Subject.java
+++ b/src/main/java/seedu/address/model/lesson/Subject.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Lesson's subject in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidSubject(String)}
  */
-public class Subject {
+public class Subject implements Comparable<Subject> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Subject should only contain alphanumeric characters and spaces, and it should not be blank";
@@ -56,6 +56,11 @@ public class Subject {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    @Override
+    public int compareTo(Subject other) {
+        return value.compareTo(other.value);
     }
 
 }

--- a/src/main/java/seedu/address/model/lesson/TimeRange.java
+++ b/src/main/java/seedu/address/model/lesson/TimeRange.java
@@ -7,6 +7,7 @@ import java.time.Duration;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Comparator;
 import java.util.Objects;
 
 /**
@@ -122,14 +123,13 @@ public class TimeRange implements Comparable<TimeRange> {
      * Compares this TimeRange object with the other TimeRange object.
      *
      * @param other The TimeRange object to compare with.
-     * @return 1, if this is later than other;0 if clashing; -1 if this is earlier.
+     * @return 1, if this is later than other; 0 if same start and end; -1 if this is earlier.
      */
     @Override
     public int compareTo(TimeRange other) {
-        /*
-        start.compareTo(other.start) will not return 0 because it will
-        be labelled as clashing with this time range.
-         */
-        return isClashing(other) ? 0 : start.compareTo(other.start);
+        // compares by start time then end time
+        return Comparator.comparing(TimeRange::getStart)
+                .thenComparing(TimeRange::getEnd)
+                .compare(this, other);
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -174,6 +175,19 @@ public class Person {
     }
 
     /**
+     * Determines equality of {@code TreeSet<Lesson>} between two persons
+     * using Lesson#equals instead of the default Lesson#compareTo.
+     *
+     * @param other The other person.
+     * @return True if all lessons in the two sets are equals, false otherwise.
+     */
+    private boolean hasEqualLessons(Person other) {
+        List<Lesson> lessons = List.copyOf(getLessons());
+        List<Lesson> otherLessons = List.copyOf(other.getLessons());
+        return lessons.containsAll(otherLessons) && otherLessons.containsAll(lessons);
+    }
+
+    /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */
@@ -199,7 +213,7 @@ public class Person {
                 && otherPerson.getAcadLevel().equals(getAcadLevel())
                 && otherPerson.getRemark().equals(getRemark())
                 && otherPerson.getTags().equals(getTags())
-                && otherPerson.getLessons().equals(getLessons())
+                && hasEqualLessons(otherPerson)
                 && otherPerson.getOutstandingFees().equals(getOutstandingFees());
     }
 

--- a/src/test/java/seedu/address/model/lesson/TimeRangeTest.java
+++ b/src/test/java/seedu/address/model/lesson/TimeRangeTest.java
@@ -62,18 +62,24 @@ public class TimeRangeTest {
     @Test
     public void compareTo() {
         TimeRange timeRange = new TimeRange("0900-1200");
+        TimeRange timeRangeCopy = new TimeRange("0900-1200");
         TimeRange laterNonClashingTimeRange = new TimeRange("1300-1500");
-        TimeRange startBeforeEndDuring = new TimeRange("0900-1000");
-        TimeRange startDuringEndAfter = new TimeRange("1030-1300");
+        TimeRange startSameEndBefore = new TimeRange("0900-1000");
+        TimeRange startAfterEndAfter = new TimeRange("1030-1300");
 
-        // clashing time ranges
-        assertEquals(0, timeRange.compareTo(startBeforeEndDuring));
-        assertEquals(0, timeRange.compareTo(startDuringEndAfter));
+        // later start time
+        assertEquals(1, startAfterEndAfter.compareTo(timeRange));
+
+        // same start time, earlier end time
+        assertEquals(-1, startSameEndBefore.compareTo(timeRange));
 
         // later time range
         assertEquals(-1, timeRange.compareTo(laterNonClashingTimeRange));
 
         // earlier time range
         assertEquals(1, laterNonClashingTimeRange.compareTo(timeRange));
+
+        // same time range
+        assertEquals(0, timeRange.compareTo(timeRangeCopy));
     }
 }


### PR DESCRIPTION
- closes https://github.com/AY2122S1-CS2103T-F13-3/tp/issues/310

Lesson ordering:
- display date
- start time
- end time
- cancelled lesson below
- recurring lesson above
- subject name alphabetical order
- last add/edited lesson goes below

Example:
These lessons all have the same display date and time range
2. Science is not cancelled, so it's above the cancelled lessons
3. Geog is recurring so it's above the makeup lessons
4. ABC is alphabetically smaller than Science
6. Science was last edited

if 5. Science were to be edited, or if 2. Science were to be cancelled, it would go below 6.
![image](https://user-images.githubusercontent.com/35279431/139886115-bf06c37b-9ee4-405f-a43f-42d14407df01.png)
