### PR TITLE
refactor Lesson toString and display

### DIFF
--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -259,19 +259,7 @@ public abstract class Lesson implements Comparable<Lesson> {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        String typeOfLesson = isRecurring() ? RECURRING : MAKEUP;
-
-        builder.append(typeOfLesson)
-                .append(" ")
-                .append("Start Date: ")
-                .append(getStartDate());
-
-        if (!getEndDate().equals(Date.MAX_DATE)) {
-            builder.append("; End Date: ")
-                   .append(getEndDate());
-        }
-
-
+        // common fields of Lesson
         builder.append("; Date: ")
                 .append(getDisplayDate())
                 .append("; Time: ")
@@ -283,23 +271,10 @@ public abstract class Lesson implements Comparable<Lesson> {
                 .append("; Lesson Rates: ")
                 .append(getLessonRates());
 
-        Set<Homework> homework = getHomework();
+        String homework = getHomework().stream().map(Homework::toString).collect(Collectors.joining(", "));
         if (!homework.isEmpty()) {
-            builder.append("; Homework: ");
-            homework.forEach(x -> builder.append(x + "; "));
-        } else {
-            builder.append("; ");
-        }
-        if (isCancelled()) {
-            builder.append("(Cancelled)");
-            return builder.toString();
-        }
-        String dates = getCancelledDates().stream().sorted()
-                .map(Date::toString).collect(Collectors.joining(","));
-
-        if (!dates.isEmpty()) {
-            builder.append("Cancelled Date(s): ")
-                    .append(dates);
+            builder.append("; Homework: ")
+                    .append(homework);
         }
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -17,11 +17,6 @@ import java.util.stream.Collectors;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public abstract class Lesson implements Comparable<Lesson> {
-
-    // Types of lesson
-    private static final String RECURRING = "Recurring";
-    private static final String MAKEUP = "Makeup";
-
     // Time fields
     private final Date startDate;
     private final Date endDate;
@@ -100,10 +95,6 @@ public abstract class Lesson implements Comparable<Lesson> {
         return timeRange.getEnd().atDate(startDate.getLocalDate());
     }
 
-    public String getTypeOfLesson() {
-        return isRecurring() ? RECURRING : MAKEUP;
-    }
-
     public LessonRates getLessonRates() {
         return lessonRates;
     }
@@ -142,6 +133,13 @@ public abstract class Lesson implements Comparable<Lesson> {
      * @return True if it is a recurring lesson, false otherwise.
      */
     public abstract boolean isRecurring();
+
+    /**
+     * Returns a string representing the type of this lesson.
+     *
+     * @return The type of this lesson.
+     */
+    public abstract String getTypeOfLesson();
 
     /**
      * Gets the date of the lesson to display to the user.

--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -145,6 +146,13 @@ public abstract class Lesson implements Comparable<Lesson> {
      * Gets the date of the lesson to display to the user.
      */
     public abstract Date getDisplayDate();
+
+    /**
+     * Gets the day of week of the lesson to display to the user.
+     */
+    public String getDisplayDayOfWeek() {
+        return getLocalDate().format(DateTimeFormatter.ofPattern("EEE"));
+    }
 
     /**
      * Gets the local date of the lesson to display to the user.

--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -258,7 +258,7 @@ public abstract class Lesson implements Comparable<Lesson> {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         // common fields of Lesson
-        builder.append("; Date: ")
+        builder.append("Date: ")
                 .append(getDisplayDate())
                 .append("; Time: ")
                 .append(getTimeRange())

--- a/src/main/java/seedu/address/model/lesson/MakeUpLesson.java
+++ b/src/main/java/seedu/address/model/lesson/MakeUpLesson.java
@@ -7,6 +7,8 @@ import java.util.Set;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class MakeUpLesson extends Lesson {
+    private static final String MAKEUP = "Makeup";
+
     /**
      * Every field must be present and not null.
      *
@@ -43,6 +45,16 @@ public class MakeUpLesson extends Lesson {
     @Override
     public boolean isRecurring() {
         return false;
+    }
+
+    /**
+     * Returns a string representing the type of this lesson.
+     *
+     * @return Makeup.
+     */
+    @Override
+    public String getTypeOfLesson() {
+        return MAKEUP;
     }
 
     /**

--- a/src/main/java/seedu/address/model/lesson/MakeUpLesson.java
+++ b/src/main/java/seedu/address/model/lesson/MakeUpLesson.java
@@ -106,12 +106,10 @@ public class MakeUpLesson extends Lesson {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
 
-        builder.append("(Makeup)")
-                .append(" ")
-                .append("Start Date: ")
-                .append(getStartDate());
-
-        builder.append(super.toString());
+        builder.append("(")
+                .append(getTypeOfLesson())
+                .append(") ")
+                .append(super.toString());
 
         if (isCancelled()) {
             builder.append("; (Cancelled)");

--- a/src/main/java/seedu/address/model/lesson/MakeUpLesson.java
+++ b/src/main/java/seedu/address/model/lesson/MakeUpLesson.java
@@ -89,5 +89,24 @@ public class MakeUpLesson extends Lesson {
     public boolean hasLessonOnDate(Date date) {
         return getStartDate().equals(date) && !isCancelled();
     }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+
+        builder.append("(Makeup)")
+                .append(" ")
+                .append("Start Date: ")
+                .append(getStartDate());
+
+        builder.append(super.toString());
+
+        if (isCancelled()) {
+            builder.append("; (Cancelled)");
+            return builder.toString();
+        }
+
+        return builder.toString();
+    }
 }
 

--- a/src/main/java/seedu/address/model/lesson/RecurringLesson.java
+++ b/src/main/java/seedu/address/model/lesson/RecurringLesson.java
@@ -16,6 +16,8 @@ import java.util.stream.Collectors;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class RecurringLesson extends Lesson {
+    private static final String RECURRING = "Recurring";
+
     /**
      * Every field must be present and not null.
      *
@@ -53,6 +55,16 @@ public class RecurringLesson extends Lesson {
     @Override
     public boolean isRecurring() {
         return true;
+    }
+
+    /**
+     * Returns a string representing the type of this lesson.
+     *
+     * @return Recurring.
+     */
+    @Override
+    public String getTypeOfLesson() {
+        return RECURRING;
     }
 
     /**

--- a/src/main/java/seedu/address/model/lesson/RecurringLesson.java
+++ b/src/main/java/seedu/address/model/lesson/RecurringLesson.java
@@ -191,8 +191,9 @@ public class RecurringLesson extends Lesson {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
 
-        builder.append("(Recurring)")
-                .append(" ")
+        builder.append("(")
+                .append(getTypeOfLesson())
+                .append(") ")
                 .append("Start Date: ")
                 .append(getStartDate());
 
@@ -201,7 +202,8 @@ public class RecurringLesson extends Lesson {
                     .append(getEndDate());
         }
 
-        builder.append(super.toString());
+        builder.append("; ")
+                .append(super.toString());
 
         String dates = getCancelledDates().stream().sorted()
                 .map(Date::toString).collect(Collectors.joining(", "));

--- a/src/main/java/seedu/address/model/lesson/RecurringLesson.java
+++ b/src/main/java/seedu/address/model/lesson/RecurringLesson.java
@@ -175,4 +175,29 @@ public class RecurringLesson extends Lesson {
                 && !getCancelledDates().contains(date); // other date is not a cancelled date
     }
 
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+
+        builder.append("(Recurring)")
+                .append(" ")
+                .append("Start Date: ")
+                .append(getStartDate());
+
+        if (!getEndDate().equals(Date.MAX_DATE)) {
+            builder.append("; End Date: ")
+                    .append(getEndDate());
+        }
+
+        builder.append(super.toString());
+
+        String dates = getCancelledDates().stream().sorted()
+                .map(Date::toString).collect(Collectors.joining(", "));
+
+        if (!dates.isEmpty()) {
+            builder.append("; Cancelled Date(s): ")
+                    .append(dates);
+        }
+        return builder.toString();
+    }
 }

--- a/src/main/java/seedu/address/ui/LessonCard.java
+++ b/src/main/java/seedu/address/ui/LessonCard.java
@@ -51,7 +51,8 @@ public class LessonCard extends UiPart<Region> {
         super(FXML);
         this.lesson = lesson;
         lessonId.setText(displayedIndex + ". ");
-        title.setText(lesson.getSubject() + " (" + lesson.getTypeOfLesson() + ")");
+        title.setText(lesson.getSubject() + " (" + lesson.getTypeOfLesson()
+                + " - " + lesson.getDisplayDayOfWeek() + ")");
         date.setText(lesson.getDisplayDate().toString());
         time.setText(lesson.getTimeRange().toString());
         rates.setText(lesson.getLessonRates().toString());

--- a/src/main/java/seedu/address/ui/ReminderLessonCard.java
+++ b/src/main/java/seedu/address/ui/ReminderLessonCard.java
@@ -40,7 +40,7 @@ public class ReminderLessonCard extends UiPart<Region> {
         this.lesson = lesson;
         this.lessonTitle.setText(lessonTitle);
         lessonId.setText(displayedIndex + ". ");
-        date.setText(lesson.getDisplayDate().value);
+        date.setText(lesson.getDisplayDate().value + " (" + lesson.getDisplayDayOfWeek() + ")");
         time.setText(lesson.getTimeRange().toString());
         rates.setText(lesson.getLessonRates().toString());
         outstandingFees.setText(lesson.getOutstandingFees().toString());


### PR DESCRIPTION
Text changes:
1. Currently, recurring lesson shows (Cancelled) in Lesson.toString if isCancelled. 
With this change, it will list all the cancelled dates instead. 
2. Makeup lesson string should only show Date without start and end date.
2. Homework separated by `,` instead of `;`
3. Add day of week in Lesson card title `Math (Recurring - Mon)`
and in Remind card `Date: 5 Nov 2021 (Fri)`